### PR TITLE
🐛 Fixes for pre 1.20.5 definitions

### DIFF
--- a/java/data/advancement/mod.mcdoc
+++ b/java/data/advancement/mod.mcdoc
@@ -113,6 +113,8 @@ enum(string) Trigger {
 	PlayerHurtEntity = "player_hurt_entity",
 	#[since="1.16"] PlayerInteractedWithEntity = "player_interacted_with_entity",
 	PlayerKilledEntity = "player_killed_entity",
+	#[since="1.20"]
+	RecipeCrafted = "recipe_crafted",
 	RecipeUnlocked = "recipe_unlocked",
 	#[since="1.18"] RideEntityInLava = "ride_entity_in_lava",
 	ShotCrossbow = "shot_crossbow",

--- a/java/data/advancement/trigger.mcdoc
+++ b/java/data/advancement/trigger.mcdoc
@@ -30,6 +30,12 @@ type Location = (
 	} |
 )
 
+type RecipeCrafted = struct {
+	...TriggerBase,
+	recipe_id: #[id="recipe"] string,
+	ingredients?: [ItemPredicate] @ 1..9,
+}
+
 #[since="1.19"]
 dispatch minecraft:trigger[allay_drop_item_on_block] to struct AllayDropItemOnBlock {
 	...TriggerBase,
@@ -95,11 +101,7 @@ dispatch minecraft:trigger[consume_item] to struct ConsumeItem {
 }
 
 #[since="1.20.5"]
-dispatch minecraft:trigger[crafter_recipe_crafted] to struct CrafterRecipeCrafted {
-	...TriggerBase,
-	recipe_id: #[id="recipe"] string,
-	ingredients?: [ItemPredicate] @ 1..9,
-}
+dispatch minecraft:trigger[crafter_recipe_crafted] to RecipeCrafted
 
 dispatch minecraft:trigger[cured_zombie_villager] to struct CuredZombieVillager {
 	...TriggerBase,
@@ -154,7 +156,7 @@ dispatch minecraft:trigger[fall_after_explosion] to struct FallAfterExplosion {
 	...TriggerBase,
 	start_position?: LocationPredicate,
 	distance?: DistancePredicate,
-	cause?: EntityPredicate,
+	cause?: CompositeEntity,
 }
 
 #[since="1.18"]
@@ -247,8 +249,8 @@ dispatch minecraft:trigger[levitation] to struct Levitation {
 /// Lightning bolt finished striking (it is already despawned), activates for all players within a 256 block radius of the strike.
 dispatch minecraft:trigger[lightning_strike] to struct LightningStrike {
 	...TriggerBase,
-	lightning?: EntityPredicate,
-	bystander?: EntityPredicate,
+	lightning?: CompositeEntity,
+	bystander?: CompositeEntity,
 }
 
 /// Activates every 20 ticks (1 second).
@@ -313,6 +315,9 @@ dispatch minecraft:trigger[player_killed_entity] to struct PlayerKilledEntity {
 	entity?: CompositeEntity,
 	killing_blow?: DamageSourcePredicate,
 }
+
+#[since="1.20"]
+dispatch minecraft:trigger[recipe_crafted] to RecipeCrafted
 
 /// Player unlocked a recipe by either crafting it, receiving it in an advancement reward, using a knowledge book, or receiving it through `/recipe`.
 dispatch minecraft:trigger[recipe_unlocked] to struct RecipeUnlocked {

--- a/java/data/enchantment.mcdoc
+++ b/java/data/enchantment.mcdoc
@@ -553,7 +553,7 @@ type EnchantmentsType = (#[id(registry="enchantment", tags="allowed")] string | 
 /// Returns a specified Enchantment
 dispatch minecraft:enchantment_provider[single] to struct SingleProvider {
 	enchantment: #[id="enchantment"] string,
-	level: IntProvider<int>
+	level: IntProvider<int>,
 }
 
 /// Gives one or more Enchantments from a set of options according to a given cost (similar to the cost value in the Enchantment Table).

--- a/java/data/enchantment.mcdoc
+++ b/java/data/enchantment.mcdoc
@@ -1,5 +1,5 @@
 use super::loot::LootCondition
-use super::util::NumberProvider
+use super::worldgen::IntProvider
 use super::util::SoundEventRef
 use ::java::data::worldgen::feature::block_state_provider::BlockStateProvider
 use ::java::data::worldgen::feature::block_predicate::BlockPredicate
@@ -550,11 +550,17 @@ dispatch minecraft:effect_component[trident_sound] to [SoundEventRef]
 
 type EnchantmentsType = (#[id(registry="enchantment", tags="allowed")] string | [#[id="enchantment"] string] @ 1..)
 
+/// Returns a specified Enchantment
+dispatch minecraft:enchantment_provider[single] to struct SingleProvider {
+	enchantment: #[id="enchantment"] string,
+	level: IntProvider<int>
+}
+
 /// Gives one or more Enchantments from a set of options according to a given cost (similar to the cost value in the Enchantment Table).
 dispatch minecraft:enchantment_provider[by_cost] to struct ByCostEnchantmentProvider {
 	enchantments: EnchantmentsType,
 	/// Cost to use for the Enchanting process.
-	cost: NumberProvider<int>,
+	cost: IntProvider<int>,
 }
 
 dispatch minecraft:enchantment_provider[by_cost_with_difficulty] to struct ByCostWithDifficultyEnchantmentProvider {

--- a/java/data/worldgen/feature/decorator.mcdoc
+++ b/java/data/worldgen/feature/decorator.mcdoc
@@ -9,6 +9,8 @@ struct ConfiguredDecorator {
 	config: minecraft:decorator_config[[type]],
 }
 
+dispatch minecraft:decorator_config[dark_oak_tree, end_gateway, iceberg, nope, spread_32_above, square] to struct {}
+
 dispatch minecraft:decorator_config[carving_mask] to struct CarvingMaskConfig {
 	step: CarveStep,
 	#[until="1.17"]

--- a/java/data/worldgen/feature/mod.mcdoc
+++ b/java/data/worldgen/feature/mod.mcdoc
@@ -348,7 +348,7 @@ dispatch minecraft:feature_config[nether_forest_vegetation] to struct NetherFore
 	...struct {
 		spread_width: int @ 1..,
 		spread_height: int @ 1..,
-	}
+	},
 }
 
 dispatch minecraft:feature_config[netherrack_replace_blobs] to struct NetherrackReplaceBlobsConfig {

--- a/java/data/worldgen/feature/mod.mcdoc
+++ b/java/data/worldgen/feature/mod.mcdoc
@@ -186,6 +186,11 @@ struct BlockPlacer {
 	...minecraft:block_placer[[type]],
 }
 
+dispatch minecraft:block_placer[
+	simple_block_placer,
+	double_plant_placer,
+] to struct {}
+
 dispatch minecraft:block_placer[column_placer] to struct ColumnPlacer {
 	#[until="1.17"]
 	min_size: int,
@@ -339,8 +344,11 @@ dispatch minecraft:feature_config[large_dripstone] to struct LargeDripstoneConfi
 
 dispatch minecraft:feature_config[nether_forest_vegetation] to struct NetherForestVegetationConfig {
 	state_provider: BlockStateProvider,
-	spread_width: int @ 1..,
-	spread_height: int @ 1..,
+	#[since="1.18"]
+	...struct {
+		spread_width: int @ 1..,
+		spread_height: int @ 1..,
+	}
 }
 
 dispatch minecraft:feature_config[netherrack_replace_blobs] to struct NetherrackReplaceBlobsConfig {

--- a/java/data/worldgen/feature/tree.mcdoc
+++ b/java/data/worldgen/feature/tree.mcdoc
@@ -91,6 +91,15 @@ struct TrunkPlacer {
 	...minecraft:trunk_placer[[type]],
 }
 
+dispatch minecraft:trunk_placer[
+	dark_oak_trunk_placer,
+	fancy_trunk_placer,
+	forking_trunk_placer,
+	giant_trunk_placer,
+	mega_jungle_trunk_placer,
+	straight_trunk_placer,
+] to struct {}
+
 #[since="1.17"]
 dispatch minecraft:trunk_placer[bending_trunk_placer] to struct BendingTrunkPlacer {
 	bend_length: IntProvider<int @ 1..64>,

--- a/java/data/worldgen/mod.mcdoc
+++ b/java/data/worldgen/mod.mcdoc
@@ -62,7 +62,7 @@ type IntProviderSettings<S, T> = (
 	#[until="1.20.5"] struct {
 		value: S<T>
 	} |
-	#[since="1.20.5"] S<T>
+	#[since="1.20.5"] S<T> |
 )
 
 type UniformIntProvider<T> = struct {

--- a/java/data/worldgen/mod.mcdoc
+++ b/java/data/worldgen/mod.mcdoc
@@ -104,7 +104,7 @@ type WeightListIntProvider<T> = struct {
 }
 
 #[since="1.18"]
-dispatch minecraft:int_provider[weighted_list] to WeightListIntProvider //Not using IntProviderSettings
+dispatch minecraft:int_provider[weighted_list] to WeightListIntProvider
 
 
 type FloatProvider<T> = (

--- a/java/data/worldgen/mod.mcdoc
+++ b/java/data/worldgen/mod.mcdoc
@@ -43,9 +43,6 @@ type IntProvider<T> = (
 	T |
 	struct {
 		type: #[id="int_provider_type"] string,
-		#[until="1.20.5"]
-		value: minecraft:int_provider[[type]]<T>,
-		#[since="1.20.5"]
 		...minecraft:int_provider[[type]]<T>,
 	} |
 )
@@ -53,20 +50,34 @@ type IntProvider<T> = (
 type ConstantIntProvider<T> = struct {
 	value: T,
 }
-dispatch minecraft:int_provider[constant] to ConstantIntProvider
+
+dispatch minecraft:int_provider[constant] to (
+	ConstantIntProvider |
+	#[until="1.20.5"] struct {
+		value: ConstantIntProvider
+	} |
+)
+
+type IntProviderSettings<S, T> = (
+	#[until="1.20.5"] struct {
+		value: S<T>
+	} |
+	#[since="1.20.5"] S<T>
+)
 
 type UniformIntProvider<T> = struct {
 	min_inclusive: T,
 	max_inclusive: T,
 }
-dispatch minecraft:int_provider[uniform,biased_to_bottom] to UniformIntProvider
+
+dispatch minecraft:int_provider[uniform,biased_to_bottom] to IntProviderSettings<UniformIntProvider>
 
 type ClampedIntProvider<T> = struct {
 	min_inclusive: T,
 	max_inclusive: T,
 	source: IntProvider<int>,
 }
-dispatch minecraft:int_provider[clamped] to ClampedIntProvider
+dispatch minecraft:int_provider[clamped] to IntProviderSettings<ClampedIntProvider>
 
 type ClampedNormalIntProvider<T> = struct {
 	...UniformIntProvider,
@@ -75,7 +86,7 @@ type ClampedNormalIntProvider<T> = struct {
 }
 
 #[since="1.18"]
-dispatch minecraft:int_provider[clamped_normal] to ClampedNormalIntProvider
+dispatch minecraft:int_provider[clamped_normal] to IntProviderSettings<ClampedNormalIntProvider>
 
 type WeightListIntProvider<T> = struct {
 	distribution: [struct {
@@ -85,7 +96,7 @@ type WeightListIntProvider<T> = struct {
 }
 
 #[since="1.18"]
-dispatch minecraft:int_provider[weighted_list] to WeightListIntProvider
+dispatch minecraft:int_provider[weighted_list] to WeightListIntProvider //Not using IntProviderSettings
 
 
 type FloatProvider<T> = (

--- a/java/data/worldgen/mod.mcdoc
+++ b/java/data/worldgen/mod.mcdoc
@@ -52,17 +52,10 @@ type ConstantIntProvider<T> = struct {
 }
 
 dispatch minecraft:int_provider[constant] to (
-	ConstantIntProvider |
 	#[until="1.20.5"] struct {
 		value: ConstantIntProvider
 	} |
-)
-
-type IntProviderSettings<S, T> = (
-	#[until="1.20.5"] struct {
-		value: S<T>
-	} |
-	#[since="1.20.5"] S<T> |
+	ConstantIntProvider |
 )
 
 type UniformIntProvider<T> = struct {
@@ -70,14 +63,24 @@ type UniformIntProvider<T> = struct {
 	max_inclusive: T,
 }
 
-dispatch minecraft:int_provider[uniform,biased_to_bottom] to IntProviderSettings<UniformIntProvider>
+dispatch minecraft:int_provider[uniform,biased_to_bottom]<T> to (
+	#[until="1.20.5"] struct {
+		value: UniformIntProvider<T>
+	} |
+	#[since="1.20.5"] UniformIntProvider<T> |
+)
 
 type ClampedIntProvider<T> = struct {
 	min_inclusive: T,
 	max_inclusive: T,
 	source: IntProvider<int>,
 }
-dispatch minecraft:int_provider[clamped] to IntProviderSettings<ClampedIntProvider>
+dispatch minecraft:int_provider[clamped]<T> to (
+	#[until="1.20.5"] struct {
+		value: ClampedIntProvider<T>
+	} |
+	#[since="1.20.5"] ClampedIntProvider<T> |
+)
 
 type ClampedNormalIntProvider<T> = struct {
 	...UniformIntProvider,
@@ -86,7 +89,12 @@ type ClampedNormalIntProvider<T> = struct {
 }
 
 #[since="1.18"]
-dispatch minecraft:int_provider[clamped_normal] to IntProviderSettings<ClampedNormalIntProvider>
+dispatch minecraft:int_provider[clamped_normal]<T> to (
+	#[until="1.20.5"] struct {
+		value: ClampedNormalIntProvider<T>
+	} |
+	#[since="1.20.5"] ClampedNormalIntProvider<T> |
+)
 
 type WeightListIntProvider<T> = struct {
 	distribution: [struct {

--- a/java/data/worldgen/noise_settings.mcdoc
+++ b/java/data/worldgen/noise_settings.mcdoc
@@ -62,6 +62,7 @@ dispatch minecraft:resource["worldgen/noise_settings"] to struct NoiseGeneratorS
 
 struct NoiseSettings {
 	/// Minimum height where blocks start generating.
+	#[since="1.17"]
 	min_y: int @ -2048..2047,
 	/// The total height where blocks can generate. Max Y = Min Y + Height.
 	height: (
@@ -106,7 +107,7 @@ struct NoiseSamplingSettings {
 
 struct NoiseSlideSettings {
 	/// The target density. Positive values add terrain and negative values remove terrain.
-	target: int,
+	target: float,
 	/// Defines a range of 'Size * Size vertical * 4' blocks where the existing density and target are interpolated.
 	size: int @ 0..256,
 	/// Defines an range of 'Offset * Size vertical * 4' blocks where the density is set to the target.

--- a/java/data/worldgen/structure.mcdoc
+++ b/java/data/worldgen/structure.mcdoc
@@ -10,7 +10,7 @@ type StructureRef = (
 	Structure |
 )
 
-dispatch minecraft:resource["worldgen/structure"] to struct Structure {
+type Structure = struct {
 	type: (
 		#[until="1.19"] #[id="worldgen/structure_feature"] string |
 		#[since="1.19"] #[id="worldgen/structure_type"] string |
@@ -38,6 +38,11 @@ dispatch minecraft:resource["worldgen/structure"] to struct Structure {
 	...minecraft:structure_config[[type]],
 }
 
+#[since="1.18.2"]
+dispatch minecraft:resource["worldgen/structure"] to Structure
+#[until="1.18.2"]
+dispatch minecraft:resource["worldgen/configured_structure_feature"] to Structure
+
 enum(string) TerrainAdaptation {
 	None = "none",
 	BeardThin = "beard_thin",
@@ -59,6 +64,18 @@ enum(string) BoundingBox {
 dispatch minecraft:jigsaw_max_distance_from_center[%none,%unknown] to int @ 1..128
 
 dispatch minecraft:jigsaw_max_distance_from_center[beard_thin,beard_box,bury] to int @ 1..116
+
+dispatch minecraft:structure_config[
+	desert_pyramid,
+	end_city,
+	fortress,
+	igloo,
+	jungle_temple,
+	ocean_monument,
+	stronghold,
+	swamp_hut,
+	woodland_mansion,
+] to struct {}
 
 dispatch minecraft:structure_config[buried_treasure] to struct BuriedTreasure {
 	#[until="1.19"]
@@ -140,7 +157,7 @@ dispatch minecraft:structure_config[
 	bastion_remnant,
 	jigsaw,
 	pillager_outpost,
-	villager,
+	village,
 ] to struct Jigsaw {
 	start_pool: #[id="worldgen/template_pool"] string,
 	size: (

--- a/java/data/worldgen/surface_builder.mcdoc
+++ b/java/data/worldgen/surface_builder.mcdoc
@@ -5,7 +5,8 @@ type ConfiguredSurfaceBuilderRef = (
 	ConfiguredSurfaceBuilder |
 )
 
-struct ConfiguredSurfaceBuilder {
+#[until="1.18"]
+dispatch minecraft:resource["worldgen/configured_surface_builder"] to struct ConfiguredSurfaceBuilder {
 	type: #[id="worldgen/surface_builder"] string,
 	config: struct {
 		top_material: BlockState,

--- a/java/data/worldgen/template_pool.mcdoc
+++ b/java/data/worldgen/template_pool.mcdoc
@@ -9,7 +9,7 @@ dispatch minecraft:resource["worldgen/template_pool"] to struct TemplatePool {
 	...struct {
 		name?: string,
 	},
-	fallback: string,
+	fallback: #[id="worldgen/template_pool"] string,
 	elements: [WeightedElement],
 }
 
@@ -53,5 +53,6 @@ dispatch minecraft:template_pool_element[
 }
 
 dispatch minecraft:template_pool_element[list_pool_element] to struct ListElement {
+	...ElementBase,
 	elements: [Element],
 }

--- a/java/server/util/particle.mcdoc
+++ b/java/server/util/particle.mcdoc
@@ -6,16 +6,21 @@ struct Particle {
 	...(minecraft:particle[[type]]),
 }
 
+type ParticleSettings<S> = struct {
+	#[until="1.20.5"]
+	value: S,
+	#[since="1.20.5"]
+	...S,
+}
+
 dispatch minecraft:particle[%unknown] to struct {}
 
-dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to (
-	#[until="1.20.5"] struct {
-		value: BlockState
-	} |
+dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to ParticleSettings<(
+	#[until="1.20.5"] BlockState |
 	#[since="1.20.5"] struct {
 		block_state: (#[id="block"] string | BlockState),
 	} |
-)
+)>
 
 /// Randomized color interpreted from three floats.
 ///
@@ -48,44 +53,38 @@ dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to (
 /// ```
 type DustColor = #[color="particle"] [float] @ 3
 
-dispatch minecraft:particle[dust] to (
+dispatch minecraft:particle[dust] to ParticleSettings<(
 	#[until="1.20.5"] struct {
-		value: struct {
-			r: float,
-			g: float,
-			b: float,
-			scale: float @ 0.01..4,
-		},
+		r: float,
+		g: float,
+		b: float,
+		scale: float @ 0.01..4,
 	} |
 	#[since="1.20.5"] struct {
 		color: DustColor,
 		scale: float @ 0.01..4,
 	} |
-)
+)>
 
-dispatch minecraft:particle[dust_color_transition] to (
-	#[until="1.20.5"] struct {
-		value: struct {
-			fromColor: DustColor,
-			toColor: DustColor,
-			scale: float @ 0.01..4,
-		},
-	} |
-	#[since="1.20.5"] struct {
-		from_color: DustColor,
-		to_color: DustColor,
-		scale: float @ 0.01..4,
-	} |
-)
+dispatch minecraft:particle[dust_color_transition] to ParticleSettings<struct {
+	#[until="1.20.5"]
+	fromColor: DustColor,
+	#[until="1.20.5"]
+	toColor: DustColor,
 
-dispatch minecraft:particle[entity_effect] to (
+	#[since="1.20.5"]
+	from_color: DustColor,
+	#[since="1.20.5"]
+	to_color: DustColor,
+	scale: float @ 0.01..4,
+}>
+
+dispatch minecraft:particle[entity_effect] to ParticleSettings<(
 	#[until="1.20.5"] struct {
-		value: struct {
-			r: float,
-			g: float,
-			b: float,
-			a: float,
-		}
+		r: float,
+		g: float,
+		b: float,
+		a: float,
 	} |
 	#[since="1.20.5"] struct {
 		/// Translucent color interpreted from four floats.
@@ -112,40 +111,32 @@ dispatch minecraft:particle[entity_effect] to (
 		/// ```
 		color: #[color="translucent_particle"] [float] @ 4,
 	} |
-)
+)>
 
-dispatch minecraft:particle[item] to (
-	#[until="1.20.5"] struct {
-		value: InventoryItem
-	} |
+dispatch minecraft:particle[item] to ParticleSettings<(
+	#[until="1.20.5"] InventoryItem |
 	#[since="1.20.5"] struct {
 		item: (#[id="item"] string | InventoryItem),
 	} |
-)
+)>
 
-dispatch minecraft:particle[sculk_charge] to (
-	#[until="1.20.5"] struct {
-		/// Angle the particle texture is rotated to, measured in radians (π ~ 3.14 for 180° clockwise, negative for counter clockwise).
-		value: float
-	} |
+dispatch minecraft:particle[sculk_charge] to ParticleSettings<(
+	#[until="1.20.5"] float |
 	#[since="1.20.5"] struct {
 		/// Angle the particle texture is rotated to, measured in radians (π ~ 3.14 for 180° clockwise, negative for counter clockwise).
 		roll: float,
 	} |
-)
+)>
 
-dispatch minecraft:particle[shriek] to (
-	#[until="1.20.5"] struct {
-		/// Ticks until the particle renders.
-		value: int @ 0.. 
-	} |
+dispatch minecraft:particle[shriek] to ParticleSettings<(
+	#[until="1.20.5"] int @ 0.. |
 	#[since="1.20.5"] struct {
 		/// Ticks until the particle renders.
 		delay: int @ 0..,
 	} |
-)
+)>
 
-type VibrationParticleSettings = struct {
+dispatch minecraft:particle[vibration] to ParticleSettings<struct {
 	/// Ticks in which to interpolate the particle's initial position to the destination.
 	arrival_in_ticks: 10,
 
@@ -160,11 +151,4 @@ type VibrationParticleSettings = struct {
 			uuid: int[] @ 4,
 		} |
 	),
-}
-
-dispatch minecraft:particle[vibration] to (
-	#[until="1.20.5"] struct {
-		value: VibrationParticleSettings
-	} |
-	#[since="1.20.5"] VibrationParticleSettings |
-)
+}>

--- a/java/server/util/particle.mcdoc
+++ b/java/server/util/particle.mcdoc
@@ -3,18 +3,24 @@ use super::inventory::InventoryItem
 
 struct Particle {
 	type: #[id="particle_type"] string,
-	#[until="1.20.5"]
-	value: minecraft:particle[[type]],
-	#[since="1.20.0"]
 	...(minecraft:particle[[type]]),
 }
 
-dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to (
+type ParticleSettings<S> = struct {
+	#[until="1.20.5"]
+	value: S,
+	#[since="1.20.5"]
+	...S,
+}
+
+dispatch minecraft:particle[%unknown] to struct {}
+
+dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to ParticleSettings<(
 	#[until="1.20.5"] BlockState |
 	#[since="1.20.5"] struct {
 		block_state: (#[id="block"] string | BlockState),
 	} |
-)
+)>
 
 /// Randomized color interpreted from three floats.
 ///
@@ -47,7 +53,7 @@ dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to (
 /// ```
 type DustColor = #[color="particle"] [float] @ 3
 
-dispatch minecraft:particle[dust] to (
+dispatch minecraft:particle[dust] to ParticleSettings<(
 	#[until="1.20.5"] struct {
 		r: float,
 		g: float,
@@ -58,9 +64,9 @@ dispatch minecraft:particle[dust] to (
 		color: DustColor,
 		scale: float @ 0.01..4,
 	} |
-)
+)>
 
-dispatch minecraft:particle[dust_color_transition] to struct {
+dispatch minecraft:particle[dust_color_transition] to ParticleSettings<struct {
 	#[until="1.20.5"]
 	fromColor: DustColor,
 	#[until="1.20.5"]
@@ -71,9 +77,9 @@ dispatch minecraft:particle[dust_color_transition] to struct {
 	#[since="1.20.5"]
 	to_color: DustColor,
 	scale: float @ 0.01..4,
-}
+}>
 
-dispatch minecraft:particle[entity_effect] to (
+dispatch minecraft:particle[entity_effect] to ParticleSettings<(
 	#[until="1.20.5"] struct {
 		r: float,
 		g: float,
@@ -105,32 +111,32 @@ dispatch minecraft:particle[entity_effect] to (
 		/// ```
 		color: #[color="translucent_particle"] [float] @ 4,
 	} |
-)
+)>
 
-dispatch minecraft:particle[item] to (
+dispatch minecraft:particle[item] to ParticleSettings<(
 	#[until="1.20.5"] InventoryItem |
 	#[since="1.20.5"] struct {
 		item: (#[id="item"] string | InventoryItem),
 	} |
-)
+)>
 
-dispatch minecraft:particle[sculk_charge] to (
+dispatch minecraft:particle[sculk_charge] to ParticleSettings<(
 	#[until="1.20.5"] float |
 	#[since="1.20.5"] struct {
 		/// Angle the particle texture is rotated to, measured in radians (π ~ 3.14 for 180° clockwise, negative for counter clockwise).
 		roll: float,
 	} |
-)
+)>
 
-dispatch minecraft:particle[shriek] to (
+dispatch minecraft:particle[shriek] to ParticleSettings<(
 	#[until="1.20.5"] int @ 0.. |
 	#[since="1.20.5"] struct {
 		/// Ticks until the particle renders.
 		delay: int @ 0..,
 	} |
-)
+)>
 
-dispatch minecraft:particle[vibration] to struct {
+dispatch minecraft:particle[vibration] to ParticleSettings<struct {
 	/// Ticks in which to interpolate the particle's initial position to the destination.
 	arrival_in_ticks: 10,
 
@@ -145,4 +151,4 @@ dispatch minecraft:particle[vibration] to struct {
 			uuid: int[] @ 4,
 		} |
 	),
-}
+}>

--- a/java/server/util/particle.mcdoc
+++ b/java/server/util/particle.mcdoc
@@ -6,21 +6,16 @@ struct Particle {
 	...(minecraft:particle[[type]]),
 }
 
-type ParticleSettings<S> = struct {
-	#[until="1.20.5"]
-	value: S,
-	#[since="1.20.5"]
-	...S,
-}
-
 dispatch minecraft:particle[%unknown] to struct {}
 
-dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to ParticleSettings<(
-	#[until="1.20.5"] BlockState |
+dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to (
+	#[until="1.20.5"] struct {
+		value: BlockState
+	} |
 	#[since="1.20.5"] struct {
 		block_state: (#[id="block"] string | BlockState),
 	} |
-)>
+)
 
 /// Randomized color interpreted from three floats.
 ///
@@ -53,38 +48,44 @@ dispatch minecraft:particle[block, falling_dust, block_marker, dust_pillar] to P
 /// ```
 type DustColor = #[color="particle"] [float] @ 3
 
-dispatch minecraft:particle[dust] to ParticleSettings<(
+dispatch minecraft:particle[dust] to (
 	#[until="1.20.5"] struct {
-		r: float,
-		g: float,
-		b: float,
-		scale: float @ 0.01..4,
+		value: struct {
+			r: float,
+			g: float,
+			b: float,
+			scale: float @ 0.01..4,
+		},
 	} |
 	#[since="1.20.5"] struct {
 		color: DustColor,
 		scale: float @ 0.01..4,
 	} |
-)>
+)
 
-dispatch minecraft:particle[dust_color_transition] to ParticleSettings<struct {
-	#[until="1.20.5"]
-	fromColor: DustColor,
-	#[until="1.20.5"]
-	toColor: DustColor,
-
-	#[since="1.20.5"]
-	from_color: DustColor,
-	#[since="1.20.5"]
-	to_color: DustColor,
-	scale: float @ 0.01..4,
-}>
-
-dispatch minecraft:particle[entity_effect] to ParticleSettings<(
+dispatch minecraft:particle[dust_color_transition] to (
 	#[until="1.20.5"] struct {
-		r: float,
-		g: float,
-		b: float,
-		a: float,
+		value: struct {
+			fromColor: DustColor,
+			toColor: DustColor,
+			scale: float @ 0.01..4,
+		},
+	} |
+	#[since="1.20.5"] struct {
+		from_color: DustColor,
+		to_color: DustColor,
+		scale: float @ 0.01..4,
+	} |
+)
+
+dispatch minecraft:particle[entity_effect] to (
+	#[until="1.20.5"] struct {
+		value: struct {
+			r: float,
+			g: float,
+			b: float,
+			a: float,
+		}
 	} |
 	#[since="1.20.5"] struct {
 		/// Translucent color interpreted from four floats.
@@ -111,32 +112,40 @@ dispatch minecraft:particle[entity_effect] to ParticleSettings<(
 		/// ```
 		color: #[color="translucent_particle"] [float] @ 4,
 	} |
-)>
+)
 
-dispatch minecraft:particle[item] to ParticleSettings<(
-	#[until="1.20.5"] InventoryItem |
+dispatch minecraft:particle[item] to (
+	#[until="1.20.5"] struct {
+		value: InventoryItem
+	} |
 	#[since="1.20.5"] struct {
 		item: (#[id="item"] string | InventoryItem),
 	} |
-)>
+)
 
-dispatch minecraft:particle[sculk_charge] to ParticleSettings<(
-	#[until="1.20.5"] float |
+dispatch minecraft:particle[sculk_charge] to (
+	#[until="1.20.5"] struct {
+		/// Angle the particle texture is rotated to, measured in radians (π ~ 3.14 for 180° clockwise, negative for counter clockwise).
+		value: float
+	} |
 	#[since="1.20.5"] struct {
 		/// Angle the particle texture is rotated to, measured in radians (π ~ 3.14 for 180° clockwise, negative for counter clockwise).
 		roll: float,
 	} |
-)>
+)
 
-dispatch minecraft:particle[shriek] to ParticleSettings<(
-	#[until="1.20.5"] int @ 0.. |
+dispatch minecraft:particle[shriek] to (
+	#[until="1.20.5"] struct {
+		/// Ticks until the particle renders.
+		value: int @ 0.. 
+	} |
 	#[since="1.20.5"] struct {
 		/// Ticks until the particle renders.
 		delay: int @ 0..,
 	} |
-)>
+)
 
-dispatch minecraft:particle[vibration] to ParticleSettings<struct {
+type VibrationParticleSettings = struct {
 	/// Ticks in which to interpolate the particle's initial position to the destination.
 	arrival_in_ticks: 10,
 
@@ -151,4 +160,11 @@ dispatch minecraft:particle[vibration] to ParticleSettings<struct {
 			uuid: int[] @ 4,
 		} |
 	),
-}>
+}
+
+dispatch minecraft:particle[vibration] to (
+	#[until="1.20.5"] struct {
+		value: VibrationParticleSettings
+	} |
+	#[since="1.20.5"] VibrationParticleSettings |
+)

--- a/java/server/world/block/decorated_pot.mcdoc
+++ b/java/server/world/block/decorated_pot.mcdoc
@@ -4,7 +4,7 @@ use ::java::server::util::InventoryItem
 dispatch minecraft:block_entity[decorated_pot] to struct DecoratedPot {
 	...super::BlockEntity,
 	/// Item ID of what was used for each side of the pot.
-	sherds?: [Sherd] @ 4,
+	sherds?: [#[id] Sherd] @ 4,
 	/// Loot table that will populate this container.
 	#[since="1.20.3"]
 	LootTable?: #[id="loot_table"] string,

--- a/java/server/world/item/block/decorated_pot.mcdoc
+++ b/java/server/world/item/block/decorated_pot.mcdoc
@@ -1,6 +1,6 @@
 use ::java::server::world::block::decorated_pot::Sherd
 
-dispatch minecraft:data_component[pot_decorations] to [Sherd] @ 4
+dispatch minecraft:data_component[pot_decorations] to [#[id] Sherd] @ 4
 
 dispatch minecraft:item_component[decorated_pot] to (
 	super::BlockItemComponents |


### PR DESCRIPTION
Fixes a lot of errors/warnings reported on old vanilla data packs (specifically 1.16.2, 1.17, 1.18, 1.19, and 1.20)

Includes a few 1.21 fixes too