### PR TITLE
🐛 Fix union spreading in multi_noise biome source

### DIFF
--- a/java/data/worldgen/dimension/biome_source.mcdoc
+++ b/java/data/worldgen/dimension/biome_source.mcdoc
@@ -1,7 +1,18 @@
-struct BiomeSource {
-	type: #[id="worldgen/biome_source"] string,
-	...minecraft:biome_source[[type]],
-}
+type BiomeSource = (
+	struct Dispatch {
+		type: #[id="worldgen/biome_source"] string,
+		...minecraft:biome_source[[type]],
+	} |
+	struct PresetMultiNoise {
+		type: #[id="worldgen/biome_source"] "multi_noise",
+		...MultiNoiseBase,
+		preset: (
+			#[until="1.18"] MultiNoisePreset |
+			#[since="1.18"] #[until="1.19.4"] #[id] MultiNoisePreset |
+			#[since="1.19.4"] #[id="worldgen/multi_noise_biome_source_parameter_list"] string |
+		),
+	} |
+)
 
 /// Biomes generate in a checkerboard chunk pattern.
 dispatch minecraft:biome_source[checkerboard] to struct Checkerboard {
@@ -17,33 +28,26 @@ dispatch minecraft:biome_source[fixed] to struct Fixed {
 	biome: #[id="worldgen/biome"] string,
 }
 
-/// Custom biome distribution with configurable parameters.
-dispatch minecraft:biome_source[multi_noise] to struct MultiNoise {
+struct MultiNoiseBase {
 	#[until="1.18"]
 	seed: long,
-	...(
-		struct {
-			preset: (
-				#[until="1.18"] MultiNoisePreset |
-				#[since="1.18"] #[until="1.19.4"] #[id] MultiNoisePreset |
-				#[since="1.19.4"] #[id="worldgen/multi_noise_biome_source_parameter_list"] string |
-			),
-		} |
-		struct {
-			#[since="1.16.2"] #[until="1.18"]
-			temperature_noise: NoiseParameters,
-			#[since="1.16.2"] #[until="1.18"]
-			humidity_noise: NoiseParameters,
-			#[since="1.16.2"] #[until="1.18"]
-			altitude_noise: NoiseParameters,
-			#[since="1.16.2"] #[until="1.18"]
-			weirdness_noise: NoiseParameters,
-			biomes: [struct {
-				biome: #[id="worldgen/biome"] string,
-				parameters: ClimateParameters,
-			}],
-		} |
-	),
+}
+
+/// Custom biome distribution with configurable parameters.
+dispatch minecraft:biome_source[multi_noise] to struct BiomesMultiNoise {
+	...MultiNoiseBase,
+	#[since="1.16.2"] #[until="1.18"]
+	temperature_noise: NoiseParameters,
+	#[since="1.16.2"] #[until="1.18"]
+	humidity_noise: NoiseParameters,
+	#[since="1.16.2"] #[until="1.18"]
+	altitude_noise: NoiseParameters,
+	#[since="1.16.2"] #[until="1.18"]
+	weirdness_noise: NoiseParameters,
+	biomes: [struct {
+		biome: #[id="worldgen/biome"] string,
+		parameters: ClimateParameters,
+	}],
 }
 
 enum(string) MultiNoisePreset {


### PR DESCRIPTION
Fixes the paremeters of the `multi_noise` biome source.