### PR TITLE
✨ 25w18a changes

### DIFF
--- a/java/assets/font.mcdoc
+++ b/java/assets/font.mcdoc
@@ -59,8 +59,14 @@ dispatch minecraft:glyph_provider[legacy_unicode] to struct LegacyUnicodeProvide
 dispatch minecraft:glyph_provider[unihex] to struct UnihexProvider {
 	/// ZIP archive containing one or more *.hex files (files in archive with different extensions are ignored).
 	hex_file: string, // TODO
-	/// List of ranges to override the size of.
-	size_overrides?: [UnihexOverrideRange],
+	#[until="1.21.6"] ...struct {
+		/// List of ranges to override the size of.
+		size_overrides: [UnihexOverrideRange],
+	},
+	#[since="1.21.6"] ...struct {
+		/// List of ranges to override the size of.
+		size_overrides?: [UnihexOverrideRange],
+	},
 }
 
 struct UnihexOverrideRange {

--- a/java/world/entity/mob/mod.mcdoc
+++ b/java/world/entity/mob/mod.mcdoc
@@ -108,7 +108,13 @@ struct MobBase {
 	#[since="1.20.5"]
 	leash?: (int[] @ 3 | struct LeashOwner {
 		UUID?: int[] @ 4
-	})
+	}),
+	/// Defaults to -1, which represents "no home".
+	#[since="1.21.6"]
+	home_radius?: int,
+	/// This field will be discarded if `home_radius` is less than 0.
+	#[since="1.21.6"]
+	home_pos?: int[] @ 3,
 }
 
 struct EntityEquipment {


### PR DESCRIPTION
- New home radius & position fields of mobs.
- `size_overrides` in unihex font provider is now optional.
  - 🐛 Actually the commit make the field required in old versions.