### PR TITLE
Update post_effect to directly reference vertex/fragment shaders

### DIFF
--- a/java/assets/shader/post.mcdoc
+++ b/java/assets/shader/post.mcdoc
@@ -52,7 +52,11 @@ type Pass = (
 		),
 	} |
 	#[since="1.21.2"] struct {
-		program: #[id="shader"] string,
+		#[until="1.21.5"] program: #[id="shader"] string,
+		#[since="1.21.5"] ...struct {
+			vertex_shader: #[id="shader/vertex"] string,
+			fragment_shader: #[id="shader/fragment"] string,
+		},
 		inputs?: [(TargetInput | TextureInput)],
 		output: #[id="shader_target"] string,
 		uniforms?: (


### PR DESCRIPTION
In 1.21.5, program json files were removed, and post_effect files no longer reference them but instead reference vertex and fragment shaders directly.