### PR TITLE
🐛 Fix potion effect and enchantment lvl in old versions

### DIFF
--- a/java/world/entity/area_effect_cloud.mcdoc
+++ b/java/world/entity/area_effect_cloud.mcdoc
@@ -45,8 +45,11 @@ dispatch minecraft:entity[area_effect_cloud] to struct AreaEffectCloud {
 	#[until="1.20.5"]
 	Potion?: #[id="potion"] string,
 	/// Potion effects that get applied on use.
-	#[until="1.20.5"]
+	#[until="1.20.2"]
 	Effects?: [MobEffectInstance],
+	/// Potion effects that get applied on use.
+	#[since="1.20.2"] #[until="1.20.5"]
+	effects?: [MobEffectInstance],
 	#[since="1.20.5"]
 	potion_contents?: minecraft:data_component[potion_contents],
 	/// The duration of the potion effect applied is scaled by this factor. Defaults to `1`.

--- a/java/world/entity/projectile/arrow.mcdoc
+++ b/java/world/entity/projectile/arrow.mcdoc
@@ -59,10 +59,10 @@ dispatch minecraft:entity[arrow] to struct Arrow {
 	#[until="1.20.2"]
 	CustomPotionEffects?: [MobEffectInstance],
 	/// Effects to give to the hit entity.
-	#[since="1.20.2"] #[until="1.20.3"]
+	#[since="1.20.2"] #[until="1.20.5"]
 	custom_potion_effects?: [MobEffectInstance],
 	/// Name of the default potion effect.
-	#[until="1.20.3"]
+	#[until="1.20.5"]
 	Potion?: #[id="mob_effect"] string,
 }
 

--- a/java/world/item/mod.mcdoc
+++ b/java/world/item/mod.mcdoc
@@ -80,7 +80,7 @@ struct Enchantment {
 	/// Which level the enchantment is.
 	lvl?: (
 		#[until="1.17"] (short @ 1.. | int @ 1..) |
-		#[since="1.17"] int @ 0..255 |
+		#[since="1.17"] short @ 0..255 |
 	),
 }
 


### PR DESCRIPTION
Fixes #74 
Fixes #75 
* After testing, starting at 1.20.2 area effect clouds uses `effects` instead of `Effects` to store custom potion effects.
* After 1.17.1 pre-1 Enchantment levels have always been `short`, until replaced by components. See [MC-131290](https://bugs.mojang.com/browse/MC/issues/MC-131290)
* Arrows still use `custom_potion_effects` and `Potion` in 1.20.4