### PR TITLE
fix: correctly mark `effects` field in `dimension_type` as optional

### DIFF
--- a/java/data/worldgen/dimension/mod.mcdoc
+++ b/java/data/worldgen/dimension/mod.mcdoc
@@ -46,7 +46,7 @@ dispatch minecraft:resource[dimension_type] to struct DimensionType {
 	),
 	/// Sky effects.
 	#[since="1.16.2"]
-	effects: #[id] DimensionTypeEffects,
+	effects?: #[id] DimensionTypeEffects,
 	/// Block tag defining what blocks keep fire infinitely burning.
 	infiniburn: (
 		#[until="1.18.2"] #[id(registry="block",tags="implicit")] string |


### PR DESCRIPTION
[The wiki](https://minecraft.wiki/w/Dimension_type) says its optional, and I tested it to be the case too