### PR TITLE
✨ Adjust pack format for 25w31a

### DIFF
--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -31,7 +31,7 @@ type OldPackVersionInfo<TOldRange> = struct {
 }
 
 type NewPackVersionInfo<TNewRange> = struct {
-	pack_format?: #[pack_format] PackFormat<TNewRange>,
+	pack_format?: #[pack_format] TNewRange,
 	description: Text,
 	min_format: #[pack_format] PackFormat<TNewRange>,
 	max_format: #[pack_format] PackFormat<TNewRange>,

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -24,6 +24,7 @@ type BasePack<VersionInfo, TOverlays> = struct {
 
 type OldPackVersionInfo<TOldRange> = struct {
 	pack_format: #[pack_format] TOldRange,
+	description: Text,
 	// This is technically only allowed to be a list of two integers in 21w31a, but that's likely
 	// a bug.
 	#[since="1.20.2"]

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -6,7 +6,7 @@ type DataPack = Pack<int @ 4..81, int @ 82..>
 
 type Pack<TOldRange, TNewRange> = (
 	BasePack<OldPackVersionInfo<TOldRange>, PackOverlays<OldPackOverlay<TOldRange>>>
-	| BasePack<NewPackVersionInfo<TNewRange>, NewPackOverlays<TNewRange>>
+	| BasePack<NewPackVersionInfo<TNewRange>, NewOrNewOldPackOverlays<TNewRange>>
 	| BasePack<NewOldPackVersionInfo<TOldRange, TNewRange>, PackOverlays<NewOldPackOverlay>>
 )
 
@@ -73,7 +73,7 @@ enum(string) FeatureFlag {
 
 // Either a list of only the new format, or a list of the format supporting old _and_ new.
 // In the latter case, at least one of the overlays must have a format version in the TOldRange.
-type NewPackOverlays<TNewRange> = (
+type NewOrNewOldPackOverlays<TNewRange> = (
 	PackOverlays<NewOldPackOverlay> |
 	PackOverlays<NewPackOverlay<TNewRange>>
 )

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -10,7 +10,10 @@ type Pack<TOldRange, TNewRange> = (
 type OldPack<TOldRange> = BasePack<OldPackVersionInfo<TOldRange>, OldPackOverlays<TOldRange>>
 
 type IntermediatePack<TOldRange, TNewRange> =
-	BasePack<IntermediatePackVersionInfo<TOldRange, TNewRange>, IntermediatePackOverlays<TOldRange>>
+	BasePack<
+		IntermediatePackVersionInfo<TOldRange, TNewRange>,
+		NewOrIntermediatePackOverlays<TOldRange, TNewRange>
+	>
 
 type NewPack<TOldRange, TNewRange> =
 	BasePack<NewPackVersionInfo<TNewRange>, NewOrIntermediatePackOverlays<TOldRange, TNewRange>>

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -1,22 +1,51 @@
 use ::java::util::text::Text
 use ::java::util::InclusiveRange
 
+type ResourcePack = Pack<int @ 1..64, int @ 65..>
+type DataPack = Pack<int @ 4..81, int @ 82..>
+
+type Pack<TOldRange, TNewRange> = (
+	BasePack<OldPackVersionInfo<TOldRange>, PackOverlays<OldPackOverlay<TOldRange>>>
+	| BasePack<NewPackVersionInfo<TNewRange>, NewPackOverlays<TNewRange>>
+	| BasePack<NewOldPackVersionInfo<TOldRange, TNewRange>, PackOverlays<NewOldPackOverlay>>
+)
+
 // `supported_formats` and `overlays` were introduced in 1.20.2,
 // but multi-version packs will use these with an older pack_format.
-struct Pack {
-	pack: struct PackBase {
-		description: Text,
-		pack_format: #[pack_format] int,
-		#[since="1.20.2"]
-		supported_formats?: InclusiveRange<#[pack_format] int>,
-	},
+type BasePack<VersionInfo, TOverlays> = struct {
+	pack: VersionInfo,
 	#[since="1.19"]
 	filter?: PackFilter,
 	#[since="1.19.3"]
 	features?: PackFeatures,
 	#[since="1.20.2"]
-	overlays?: PackOverlays,
+	overlays?: TOverlays,
 }
+
+type OldPackVersionInfo<TOldRange> = struct {
+	pack_format: #[pack_format] TOldRange,
+	// This is technically only allowed to be a list of two integers in 21w31a, but that's likely
+	// a bug.
+	#[since="1.20.2"]
+	supported_formats?: InclusiveRange<#[pack_format] TOldRange>,
+}
+
+type NewPackVersionInfo<TNewRange> = struct {
+	pack_format?: #[pack_format] PackFormat<TNewRange>,
+	min_format: #[pack_format] PackFormat<TNewRange>,
+	max_format: #[pack_format] PackFormat<TNewRange>,
+}
+
+type NewOldPackVersionInfo<TOldRange, TNewRange> = struct {
+	pack_format: #[pack_format] int,
+	min_format: #[pack_format] PackFormat<TOldRange>,
+	max_format: #[pack_format] PackFormat<TNewRange>,
+	supported_formats: [#[pack_format] TOldRange, #[pack_format] TNewRange],
+}
+
+type PackVersionInfo<TOldRange, TNewRange> = (OldPackVersionInfo<TOldRange> | NewPackVersionInfo<TNewRange> | NewOldPackVersionInfo<TOldRange, TNewRange>)
+
+type PackFormat<T> = (T | [T] @ 1 | [T, int @ 0..])
 
 struct PackFilter {
 	block: [BlockPattern],
@@ -42,11 +71,33 @@ enum(string) FeatureFlag {
 	#[since="1.21.2"] #[until="1.21.4"] WinterDrop = "winter_drop",
 }
 
-struct PackOverlays {
-	entries: [PackOverlay],
+// Either a list of only the new format, or a list of the format supporting old _and_ new.
+// In the latter case, at least one of the overlays must have a format version in the TOldRange.
+type NewPackOverlays<TNewRange> = (
+	PackOverlays<NewOldPackOverlay> |
+	PackOverlays<NewPackOverlay<TNewRange>>
+)
+
+type PackOverlays<T> = struct {
+	entries: [T],
 }
 
-struct PackOverlay {
+type OldPackOverlay<TOldRange> = struct {
 	directory: string @ 1..,
-	formats: InclusiveRange<#[pack_format] int>,
+	// This is technically only allowed to be a list of two integers in 21w31a, but that's likely
+	// a bug.
+	formats: InclusiveRange<#[pack_format] TOldRange>,
+}
+
+type NewPackOverlay<TNewRange> = struct {
+	directory: string @ 1..,
+	min_format: #[pack_format] PackFormat<TNewRange>,
+	max_format: #[pack_format] PackFormat<TNewRange>,
+}
+
+struct NewOldPackOverlay {
+	directory: string @ 1..,
+	formats: [#[pack_format] int] @ 2,
+	min_format: #[pack_format] PackFormat<int>,
+	max_format: #[pack_format] PackFormat<int>,
 }

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -6,8 +6,8 @@ type DataPack = Pack<int @ 4..81, int @ 82..>
 
 type Pack<TOldRange, TNewRange> = (
 	BasePack<OldPackVersionInfo<TOldRange>, OldPackOverlays<TOldRange>>
-	| BasePack<NewPackVersionInfo<TNewRange>, NewOrNewOldPackOverlays<TNewRange>>
-	| BasePack<NewOldPackVersionInfo<TOldRange, TNewRange>, NewOldPackOverlays<TOldRange>>
+	| BasePack<NewPackVersionInfo<TNewRange>, NewOrIntermediatePackOverlays<TNewRange>>
+	| BasePack<IntermediatePackVersionInfo<TOldRange, TNewRange>, IntermediatePackOverlays<TOldRange>>
 )
 
 // `supported_formats` and `overlays` were introduced in 1.20.2,
@@ -36,14 +36,14 @@ type NewPackVersionInfo<TNewRange> = struct {
 	max_format: #[pack_format] PackFormat<TNewRange>,
 }
 
-type NewOldPackVersionInfo<TOldRange, TNewRange> = struct {
+type IntermediatePackVersionInfo<TOldRange, TNewRange> = struct {
 	pack_format: #[pack_format] int,
 	min_format: #[pack_format] PackFormat<TOldRange>,
 	max_format: #[pack_format] PackFormat<TNewRange>,
 	supported_formats: [#[pack_format] TOldRange, #[pack_format] TNewRange],
 }
 
-type PackVersionInfo<TOldRange, TNewRange> = (OldPackVersionInfo<TOldRange> | NewPackVersionInfo<TNewRange> | NewOldPackVersionInfo<TOldRange, TNewRange>)
+type PackVersionInfo<TOldRange, TNewRange> = (OldPackVersionInfo<TOldRange> | NewPackVersionInfo<TNewRange> | IntermediatePackVersionInfo<TOldRange, TNewRange>)
 
 type PackFormat<T> = (T | [T] @ 1 | [T, int @ 0..])
 
@@ -76,8 +76,8 @@ type NewPackOverlays<TNewRange> = PackOverlays<NewPackOverlay<TNewRange>>
 
 // This enforces all overlays to include the formats field. min_version and max_version also must
 // be present if the format is outside the TOldRange, and are otherwise optional.
-type NewOldPackOverlays<TOldRange> = PackOverlays<
-	(OldPackOverlay<TOldRange> | NewOldPackOverlay)
+type IntermediatePackOverlays<TOldRange> = PackOverlays<
+	(OldPackOverlay<TOldRange> | IntermediatePackOverlay)
 >
 
 // This enforces either a list of overlays without the formats field and only
@@ -89,8 +89,8 @@ type NewOldPackOverlays<TOldRange> = PackOverlays<
 //
 // In Minecraft, it is only possible to define overlays with the `formats` field if at least one
 // overlay is targeting TOldRange. This is not validated by this type due to limitations of mcdoc.
-type NewOrNewOldPackOverlays<TOldRange, TNewRange> = (
-	NewOldPackOverlays<TOldRange> |
+type NewOrIntermediatePackOverlays<TOldRange, TNewRange> = (
+	IntermediatePackOverlays<TOldRange> |
 	NewPackOverlays<TNewRange>
 )
 
@@ -111,7 +111,7 @@ type NewPackOverlay<TNewRange> = struct {
 	max_format: #[pack_format] PackFormat<TNewRange>,
 }
 
-struct NewOldPackOverlay {
+struct IntermediatePackOverlay {
 	directory: string @ 1..,
 	formats: [#[pack_format] int] @ 2,
 	min_format: #[pack_format] PackFormat<int>,

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -32,12 +32,14 @@ type OldPackVersionInfo<TOldRange> = struct {
 
 type NewPackVersionInfo<TNewRange> = struct {
 	pack_format?: #[pack_format] PackFormat<TNewRange>,
+	description: Text,
 	min_format: #[pack_format] PackFormat<TNewRange>,
 	max_format: #[pack_format] PackFormat<TNewRange>,
 }
 
 type IntermediatePackVersionInfo<TOldRange, TNewRange> = struct {
 	pack_format: #[pack_format] int,
+	description: Text,
 	min_format: #[pack_format] PackFormat<TOldRange>,
 	max_format: #[pack_format] PackFormat<TNewRange>,
 	supported_formats: [#[pack_format] TOldRange, #[pack_format] TNewRange],

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -74,8 +74,8 @@ enum(string) FeatureFlag {
 type OldPackOverlays<TOldRange> = PackOverlays<OldPackOverlay<TOldRange>>
 type NewPackOverlays<TNewRange> = PackOverlays<NewPackOverlay<TNewRange>>
 
-// This enforces all overlays to include the formats field.min_version and max_version also must
-// be present, if the format is outside the TOldRange, and are otherwise optional.
+// This enforces all overlays to include the formats field. min_version and max_version also must
+// be present if the format is outside the TOldRange, and are otherwise optional.
 type NewOldPackOverlays<TOldRange> = PackOverlays<
 	(OldPackOverlay<TOldRange> | NewOldPackOverlay)
 >
@@ -85,7 +85,10 @@ type NewOldPackOverlays<TOldRange> = PackOverlays<
 // outside of TOldRange, min_format and max_format become optional.
 //
 // This is used in case the min_format / max_format range is in the TNewRange. This still allows
-// for overlays for versions outside of the range without guranteeing compatiblity
+// for overlays for versions outside of the range without guranteeing compatiblity.
+//
+// In Minecraft, it is only possible to define overlays with the `formats` field if at least one
+// overlay is targeting TOldRange. This is not validated by this type due to limitations of mcdoc.
 type NewOrNewOldPackOverlays<TOldRange, TNewRange> = (
 	NewOldPackOverlays<TOldRange> |
 	NewPackOverlays<TNewRange>

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -1,14 +1,19 @@
 use ::java::util::text::Text
 use ::java::util::InclusiveRange
 
-type ResourcePack = Pack<int @ 1..64, int @ 65..>
-type DataPack = Pack<int @ 4..81, int @ 82..>
-
 type Pack<TOldRange, TNewRange> = (
-	BasePack<OldPackVersionInfo<TOldRange>, OldPackOverlays<TOldRange>>
-	| BasePack<NewPackVersionInfo<TNewRange>, NewOrIntermediatePackOverlays<TOldRange, TNewRange>>
-	| BasePack<IntermediatePackVersionInfo<TOldRange, TNewRange>, IntermediatePackOverlays<TOldRange>>
+	OldPack<TOldRange>
+	| IntermediatePack<TOldRange, TNewRange>
+	| NewPack<TOldRange, TNewRange>
 )
+
+type OldPack<TOldRange> = BasePack<OldPackVersionInfo<TOldRange>, OldPackOverlays<TOldRange>>
+
+type IntermediatePack<TOldRange, TNewRange> =
+	BasePack<IntermediatePackVersionInfo<TOldRange, TNewRange>, IntermediatePackOverlays<TOldRange>>
+
+type NewPack<TOldRange, TNewRange> =
+	BasePack<NewPackVersionInfo<TNewRange>, NewOrIntermediatePackOverlays<TOldRange, TNewRange>>
 
 // `supported_formats` and `overlays` were introduced in 1.20.2,
 // but multi-version packs will use these with an older pack_format.

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -5,9 +5,9 @@ type ResourcePack = Pack<int @ 1..64, int @ 65..>
 type DataPack = Pack<int @ 4..81, int @ 82..>
 
 type Pack<TOldRange, TNewRange> = (
-	BasePack<OldPackVersionInfo<TOldRange>, PackOverlays<OldPackOverlay<TOldRange>>>
+	BasePack<OldPackVersionInfo<TOldRange>, OldPackOverlays<TOldRange>>
 	| BasePack<NewPackVersionInfo<TNewRange>, NewOrNewOldPackOverlays<TNewRange>>
-	| BasePack<NewOldPackVersionInfo<TOldRange, TNewRange>, PackOverlays<NewOldPackOverlay>>
+	| BasePack<NewOldPackVersionInfo<TOldRange, TNewRange>, NewOldPackOverlays<TOldRange>>
 )
 
 // `supported_formats` and `overlays` were introduced in 1.20.2,
@@ -71,11 +71,24 @@ enum(string) FeatureFlag {
 	#[since="1.21.2"] #[until="1.21.4"] WinterDrop = "winter_drop",
 }
 
-// Either a list of only the new format, or a list of the format supporting old _and_ new.
-// In the latter case, at least one of the overlays must have a format version in the TOldRange.
-type NewOrNewOldPackOverlays<TNewRange> = (
-	PackOverlays<NewOldPackOverlay> |
-	PackOverlays<NewPackOverlay<TNewRange>>
+type OldPackOverlays<TOldRange> = PackOverlays<OldPackOverlay<TOldRange>>
+type NewPackOverlays<TNewRange> = PackOverlays<NewPackOverlay<TNewRange>>
+
+// This enforces all overlays to include the formats field.min_version and max_version also must
+// be present, if the format is outside the TOldRange, and are otherwise optional.
+type NewOldPackOverlays<TOldRange> = PackOverlays<
+	(OldPackOverlay<TOldRange> | NewOldPackOverlay)
+>
+
+// This enforces either a list of overlays without the formats field and only
+// min_version and max_version, or a list that always has the formats field, and for versions
+// outside of TOldRange, min_format and max_format become optional.
+//
+// This is used in case the min_format / max_format range is in the TNewRange. This still allows
+// for overlays for versions outside of the range without guranteeing compatiblity
+type NewOrNewOldPackOverlays<TOldRange, TNewRange> = (
+	NewOldPackOverlays<TOldRange> |
+	NewPackOverlays<TNewRange>
 )
 
 type PackOverlays<T> = struct {

--- a/java/pack.mcdoc
+++ b/java/pack.mcdoc
@@ -6,7 +6,7 @@ type DataPack = Pack<int @ 4..81, int @ 82..>
 
 type Pack<TOldRange, TNewRange> = (
 	BasePack<OldPackVersionInfo<TOldRange>, OldPackOverlays<TOldRange>>
-	| BasePack<NewPackVersionInfo<TNewRange>, NewOrIntermediatePackOverlays<TNewRange>>
+	| BasePack<NewPackVersionInfo<TNewRange>, NewOrIntermediatePackOverlays<TOldRange, TNewRange>>
 	| BasePack<IntermediatePackVersionInfo<TOldRange, TNewRange>, IntermediatePackOverlays<TOldRange>>
 )
 


### PR DESCRIPTION
Only pack changes, from my idea discussed on Discord.

This is a draft to be discussed. Currently conflicting with #84 which has a more rudimentary version of the pack.mcmeta changes.

If this is merged, it requires readers (e.g. Spyglass) to use `::java::pack::ResourcePack` for resource pack mcmetas, and `DataPack` for data pack mcmetas.