### PR TITLE
🐛 Disallow loot condition/function references in "experimental" resources

### DIFF
--- a/java/data/enchantment/effect_component.mcdoc
+++ b/java/data/enchantment/effect_component.mcdoc
@@ -1,4 +1,4 @@
-use ::java::data::loot::LootCondition
+use ::java::data::predicate::NonReferencePredicate
 use ::java::data::util::SoundEventRef
 use super::effect::ValueEffect
 use super::effect::EntityEffect
@@ -13,7 +13,7 @@ struct EnchantmentEffectComponentMap {
 
 dispatch minecraft:effect_component[armor_effectiveness] to [struct ArmorEffectivenessEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Determines armor effectiveness; `0.0` for no effect, `1.0` for full effect.
 	effect: ValueEffect,
 }]
@@ -22,7 +22,7 @@ dispatch minecraft:effect_component[attributes] to [AttributeEffect]
 
 dispatch minecraft:effect_component[ammo_use] to [struct AmmoUseEnchantmentEffect {
 	/// Predicate context: Item Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of ammunition being used up. \
 	/// `0` has a side effect of applying `intangible_projectile` component to the projectile item.
 	effect: ValueEffect,
@@ -30,7 +30,7 @@ dispatch minecraft:effect_component[ammo_use] to [struct AmmoUseEnchantmentEffec
 
 dispatch minecraft:effect_component[block_experience] to [struct BlockExperienceEnchantmentEffect {
 	/// Predicate context: Item Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of experience awarded.
 	effect: ValueEffect,
 }]
@@ -50,7 +50,7 @@ dispatch minecraft:effect_component[crossbow_charge_time] to ValueEffect
 
 dispatch minecraft:effect_component[damage] to [struct DamageEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Damage dealt by the weapon.
 	effect: ValueEffect,
 }]
@@ -58,14 +58,14 @@ dispatch minecraft:effect_component[damage] to [struct DamageEnchantmentEffect {
 /// Complete damage immunity given the conditions are met.
 dispatch minecraft:effect_component[damage_immunity] to [struct DamageImmunityEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Dummy value; this is a boolean effect.
 	effect: struct {},
 }]
 
 dispatch minecraft:effect_component[damage_protection] to [struct DamageProtectionEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Damage reduction factor. \
 	/// Provides `factor * 4%` of damage reduction, capped at 80%.
 	effect: ValueEffect,
@@ -74,7 +74,7 @@ dispatch minecraft:effect_component[damage_protection] to [struct DamageProtecti
 /// Chance of equipment dropping when a target is killed by the owner of the Enchanted Item.
 dispatch minecraft:effect_component[equipment_drops] to [struct EquipmentDropsEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Chance between `0.0` and `1.0` of an equipped piece dropping. \
 	/// If the drop chance on mob is 0, the chance will not be affected by this effect.
 	effect: ValueEffect,
@@ -86,7 +86,7 @@ dispatch minecraft:effect_component[fishing_luck_bonus] to [struct FishingLuckBo
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the player fishing.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of luck being added.
 	effect: ValueEffect,
 }]
@@ -95,7 +95,7 @@ dispatch minecraft:effect_component[fishing_time_reduction] to [struct FishingTi
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the player fishing.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Time reduction in seconds (higher values mean less time until a fish bites).
 	effect: ValueEffect,
 }]
@@ -104,28 +104,28 @@ dispatch minecraft:effect_component[hit_block] to [struct HitBlockEnchantmentEff
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the entity hitting the Block, unless during a projectile attack, then, `this` is the projectile.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// On the entity hitting the Block
 	effect: EntityEffect,
 }]
 
 dispatch minecraft:effect_component[knockback] to [struct KnockbackEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of knockback being applied.
 	effect: ValueEffect,
 }]
 
 dispatch minecraft:effect_component[item_damage] to [struct ItemDamageEnchantmentEffect {
 	/// Predicate context: Item Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of damage being dealt to the item.
 	effect: ValueEffect,
 }]
 
 dispatch minecraft:effect_component[location_changed] to [struct LocationChangedEnchantmentEffect {
 	/// Predicate context: Location Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// On the entity changing location.
 	effect: LocationBasedEffect,
 }]
@@ -134,14 +134,14 @@ dispatch minecraft:effect_component[mob_experience] to [struct MobExperienceEnch
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the killed mob.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of experience awarded.
 	effect: ValueEffect,
 }]
 
 dispatch minecraft:effect_component[post_attack] to [struct PostAttackEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Examples:
 	/// - A Fire Aspect Enchant would specify that when the attacker is enchanted, the `ignite` effect is applied, and the affected party is the victim.
 	/// - Thorns would specify that when the victim is enchanted, the `damage_entity` effect is applied, and the affected party is the attacker.
@@ -160,7 +160,7 @@ enum(string) AttackTarget {
 #[since="1.21.11"]
 dispatch minecraft:effect_component[post_piercing_attack] to [struct PostPiercingAttackEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// The effect to apply on attacker.
 	effect: EntityEffect,
 }]
@@ -175,7 +175,7 @@ dispatch minecraft:effect_component[projectile_count] to [struct ProjectileCount
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the entity drawing the weapon.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of projectiles being loaded/drawn. \
 	/// All projectile items except the first one will have `intangible_projectile` component applied.
 	effect: ValueEffect,
@@ -186,7 +186,7 @@ dispatch minecraft:effect_component[projectile_piercing] to [struct ProjectilePi
 	/// Predicate context: Item Parameters.
 	///
 	/// Tool is the ammunition item.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of entities the projectile will pierce through before despawning.
 	effect: ValueEffect,
 }]
@@ -196,7 +196,7 @@ dispatch minecraft:effect_component[projectile_spread] to [struct ProjectileSpre
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the entity shooting the projectile.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Maximum spread of projectiles measured in degrees from the aim line.
 	effect: ValueEffect,
 }]
@@ -206,7 +206,7 @@ dispatch minecraft:effect_component[projectile_spawned] to [struct ProjectileSpa
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the newly spawned projectile.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// On the newly spawned projectile.
 	effect: EntityEffect,
 }]
@@ -214,7 +214,7 @@ dispatch minecraft:effect_component[projectile_spawned] to [struct ProjectileSpa
 /// Repairs the enchanted item with experience points picked up by the player.
 dispatch minecraft:effect_component[repair_with_xp] to [struct RepairWithXpEnchantmentEffect {
 	/// Predicate context: Item Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of durability increase per experience point, `mending` uses 2x.
 	effect: ValueEffect,
 }]
@@ -222,7 +222,7 @@ dispatch minecraft:effect_component[repair_with_xp] to [struct RepairWithXpEncha
 /// Amount of damage caused by a Mace's smash attack per block fallen.
 dispatch minecraft:effect_component[smash_damage_per_block_fallen] to [struct SmashDamagePerBlockFallenEnchantmentEffect {
 	/// Predicate context: Damage Parameters.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of damage dealt per block fallen.
 	effect: ValueEffect,
 }]
@@ -231,7 +231,7 @@ dispatch minecraft:effect_component[tick] to [struct TickEnchantmentEffect {
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the entity with the Enchanted Item.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// On every tick. Performance recommendation: don't use with `run_function` unless necessary.
 	effect: EntityEffect,
 }]
@@ -240,7 +240,7 @@ dispatch minecraft:effect_component[trident_return_acceleration] to [struct Trid
 	/// Predicate context: Entity Parameters.
 	///
 	/// `this` is the trident entity.
-	requirements?: (LootCondition | [LootCondition]),
+	requirements?: NonReferencePredicate,
 	/// Amount of acceleration applied to the returning trident.
 	effect: ValueEffect,
 }]

--- a/java/data/item_modifier.mcdoc
+++ b/java/data/item_modifier.mcdoc
@@ -1,7 +1,8 @@
 use super::loot::LootFunction
-use super::loot::LootCondition
+use super::loot::NonReferenceLootFunction
 
 type ItemModifier = (LootFunction | [LootFunction])
+type NonReferenceItemModifier = (NonReferenceLootFunction | [NonReferenceLootFunction])
 
 #[since="1.17"]
 dispatch minecraft:resource[item_modifier] to ItemModifier

--- a/java/data/loot/condition.mcdoc
+++ b/java/data/loot/condition.mcdoc
@@ -1,4 +1,3 @@
-use super::LootCondition
 use super::EntityTarget
 use super::super::enchantment::LevelBasedValue
 use super::super::util::IntRange
@@ -9,45 +8,53 @@ use super::super::advancement::predicate::EntityPredicate
 use super::super::advancement::predicate::LocationPredicate
 use super::super::advancement::predicate::DamageSourcePredicate
 
+type LootConditionOf<C> = struct {
+	condition: (
+		#[until="1.16"] #[id] super::LootConditionType |
+		#[since="1.16"] C |
+	),
+	...minecraft:loot_condition[[condition]]<C>,
+}
+
 /// Whether any condition within a list passes.
 #[until="1.20"]
-dispatch minecraft:loot_condition[alternative] to struct Alternative {
-	terms: [LootCondition],
+dispatch minecraft:loot_condition[alternative]<C> to struct Alternative {
+	terms: [LootConditionOf<C>],
 }
 
 #[since="1.20"]
-dispatch minecraft:loot_condition[any_of] to struct AnyOf {
+dispatch minecraft:loot_condition[any_of]<C> to struct AnyOf {
 	/// Passes when any of these conditions pass.
-	terms: [LootCondition],
+	terms: [LootConditionOf<C>],
 }
 
 #[since="1.20"]
-dispatch minecraft:loot_condition[all_of] to struct AllOf {
+dispatch minecraft:loot_condition[all_of]<C> to struct AllOf {
 	/// Passes when all of these conditions pass.
-	terms: [LootCondition],
+	terms: [LootConditionOf<C>],
 }
 
-dispatch minecraft:loot_condition[block_state_property] to struct BlockStateProperty {
+dispatch minecraft:loot_condition[block_state_property]<C> to struct BlockStateProperty {
 	block: #[id="block"] string,
 	// TODO: was this optional in 1.20.2 and before? (wasn't codecified yet)
 	properties?: mcdoc:block_states[[block]],
 }
 
-dispatch minecraft:loot_condition[damage_source_properties] to struct DamageSourceProperties {
+dispatch minecraft:loot_condition[damage_source_properties]<C> to struct DamageSourceProperties {
 	predicate: DamageSourcePredicate,
 }
 
 /// Requires the "Enchantment Active" parameter to exist in the context, which currently means it only works in Enchantment conditions.
-dispatch minecraft:loot_condition[enchantment_active_check] to struct EnchantmentActiveCheck {
+dispatch minecraft:loot_condition[enchantment_active_check]<C> to struct EnchantmentActiveCheck {
 	active: boolean,
 }
 
-dispatch minecraft:loot_condition[entity_properties] to struct EntityProperties {
+dispatch minecraft:loot_condition[entity_properties]<C> to struct EntityProperties {
 	entity: EntityTarget,
 	predicate: EntityPredicate,
 }
 
-dispatch minecraft:loot_condition[entity_scores] to struct EntityScores {
+dispatch minecraft:loot_condition[entity_scores]<C> to struct EntityScores {
 	entity: EntityTarget,
 	scores: struct {
 		[#[objective] string]: (
@@ -58,32 +65,32 @@ dispatch minecraft:loot_condition[entity_scores] to struct EntityScores {
 }
 
 #[since="26.1"]
-dispatch minecraft:loot_condition[environment_attribute_check] to struct EnvironmentAttributeCheck {
+dispatch minecraft:loot_condition[environment_attribute_check]<C> to struct EnvironmentAttributeCheck {
 	attribute: #[id="environment_attribute"] string,
 	value: minecraft:environment_attribute[[attribute]][value],
 }
 
 /// Whether a condition does not pass.
-dispatch minecraft:loot_condition[inverted] to struct Inverted {
-	term: LootCondition,
+dispatch minecraft:loot_condition[inverted]<C> to struct Inverted {
+	term: LootConditionOf<C>,
 }
 
-dispatch minecraft:loot_condition[killed_by_player] to struct KilledByPlayer {
+dispatch minecraft:loot_condition[killed_by_player]<C> to struct KilledByPlayer {
 	inverse?: boolean,
 }
 
-dispatch minecraft:loot_condition[location_check] to struct LocationCheck {
+dispatch minecraft:loot_condition[location_check]<C> to struct LocationCheck {
 	offsetX?: int,
 	offsetY?: int,
 	offsetZ?: int,
 	predicate: LocationPredicate,
 }
 
-dispatch minecraft:loot_condition[match_tool] to struct MatchTool {
+dispatch minecraft:loot_condition[match_tool]<C> to struct MatchTool {
 	predicate: ItemPredicate,
 }
 
-dispatch minecraft:loot_condition[random_chance] to struct RandomChance {
+dispatch minecraft:loot_condition[random_chance]<C> to struct RandomChance {
 	/// Clamps to a float between `0` & `1` (inclusive).
 	chance: (
 		#[until="1.21"] float @ 0..1 |
@@ -92,32 +99,32 @@ dispatch minecraft:loot_condition[random_chance] to struct RandomChance {
 }
 
 #[until="1.21"]
-dispatch minecraft:loot_condition[random_chance_with_looting] to struct RandomChanceWithLooting {
+dispatch minecraft:loot_condition[random_chance_with_looting]<C> to struct RandomChanceWithLooting {
 	chance: float @ 0..1,
 	/// Looting adjustment to the base success rate. Formula is `chance + (looting_level * looting_multiplier)` .
 	looting_multiplier: float,
 }
 
 #[since="1.21"]
-dispatch minecraft:loot_condition[random_chance_with_enchanted_bonus] to struct RandomChanceWithEnchantedBonus {
+dispatch minecraft:loot_condition[random_chance_with_enchanted_bonus]<C> to struct RandomChanceWithEnchantedBonus {
 	unenchanted_chance: float @ 0..1,
 	enchanted_chance: LevelBasedValue,
 	enchantment: #[id="enchantment"] string,
 }
 
 /// Whether another predicate passes.
-dispatch minecraft:loot_condition[reference] to struct Reference {
+dispatch minecraft:loot_condition[reference]<C> to struct Reference {
 	/// A cyclic reference causes a parsing failure.
 	name: #[id="predicate"] string,
 }
 
-dispatch minecraft:loot_condition[table_bonus] to struct TableBonus {
+dispatch minecraft:loot_condition[table_bonus]<C> to struct TableBonus {
 	enchantment: #[id="enchantment"] string,
 	/// Probabilities for each enchantment level
 	chances: [float @ 0..1],
 }
 
-dispatch minecraft:loot_condition[time_check] to struct TimeCheck {
+dispatch minecraft:loot_condition[time_check]<C> to struct TimeCheck {
 	/// The world clock to check.
 	#[since="26.1"]
 	clock: #[id="world_clock"] string,
@@ -132,14 +139,14 @@ dispatch minecraft:loot_condition[time_check] to struct TimeCheck {
 }
 
 #[since="1.17"]
-dispatch minecraft:loot_condition[value_check] to struct ValueCheck {
+dispatch minecraft:loot_condition[value_check]<C> to struct ValueCheck {
 	/// Clamps to an integer.
 	value: NumberProvider,
 	/// Passes when `value` is within this range.
 	range: IntRange,
 }
 
-dispatch minecraft:loot_condition[weather_check] to struct WeatherCheck {
+dispatch minecraft:loot_condition[weather_check]<C> to struct WeatherCheck {
 	raining?: boolean,
 	thundering?: boolean,
 }

--- a/java/data/loot/function.mcdoc
+++ b/java/data/loot/function.mcdoc
@@ -1,6 +1,5 @@
 use super::LootPoolEntry
-use super::LootCondition
-use super::LootFunction
+use super::condition::LootConditionOf
 use super::EntityTarget
 use super::BlockEntityTarget
 use super::ItemStackTarget
@@ -22,15 +21,23 @@ use ::java::world::component::DataComponentPatch
 use ::java::world::component::CustomData
 use ::java::world::component::item::FireworkShape
 
-struct Conditions {
-	conditions?: [LootCondition],
+type Conditions<C> = struct {
+	conditions?: [LootConditionOf<C>],
 }
 
-dispatch minecraft:loot_function[apply_bonus] to struct ApplyBonus {
+type LootFunctionOf<F, C> = struct {
+	function: (
+		#[until="1.16"] #[id] super::LootFunctionType |
+		#[since="1.16"] F |
+	),
+	...minecraft:loot_function[[function]]<F, C>,
+}
+
+dispatch minecraft:loot_function[apply_bonus]<F, C> to struct ApplyBonus {
 	enchantment: #[id="enchantment"] string,
 	formula: #[id] ApplyBonusFormula,
 	...minecraft:apply_bonus_formula[[formula]],
-	...Conditions,
+	...Conditions<C>,
 }
 
 enum(string) ApplyBonusFormula {
@@ -58,13 +65,13 @@ dispatch minecraft:apply_bonus_formula[binomial_with_bonus_count] to struct Bino
 }
 
 /// Copies `CustomName` tag from an entity or block entity into the item's `custom_name` component.
-dispatch minecraft:loot_function[copy_name] to struct CopyName {
+dispatch minecraft:loot_function[copy_name]<F, C> to struct CopyName {
 	source: (
 		#[until="1.21.9"] CopyNameSource |
 		#[since="1.21.9"] EntityTarget | 
 		#[since="1.21.9"] BlockEntityTarget |
 	),
-	...Conditions,
+	...Conditions<C>,
 }
 
 enum(string) CopyNameSource {
@@ -76,7 +83,7 @@ enum(string) CopyNameSource {
 	BlockEntity = "block_entity",
 }
 
-struct CopyNbt {
+type CopyNbt<C> = struct {
 	source: NbtProvider,
 	ops: [(struct CopyNbtOperation {
 		source: #[nbt_path] string, // TODO
@@ -86,17 +93,17 @@ struct CopyNbt {
 		),
 		op: CopyNbtStrategy
 	})],
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[until="1.20.5"]
-dispatch minecraft:loot_function[copy_nbt] to CopyNbt
+dispatch minecraft:loot_function[copy_nbt]<F, C> to CopyNbt<C>
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[copy_custom_data] to CopyNbt
+dispatch minecraft:loot_function[copy_custom_data]<F, C> to CopyNbt<C>
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[copy_components] to struct CopyComponents {
+dispatch minecraft:loot_function[copy_components]<F, C> to struct CopyComponents {
 	source: (
 		BlockEntityTarget |
 		#[since="1.21.9"] EntityTarget |
@@ -106,7 +113,7 @@ dispatch minecraft:loot_function[copy_components] to struct CopyComponents {
 	include?: [#[id="data_component_type"] string],
 	/// Defaults to none.
 	exclude?: [#[id="data_component_type"] string],
-	...Conditions,
+	...Conditions<C>,
 }
 
 enum(string) CopyNbtStrategy {
@@ -119,21 +126,21 @@ enum(string) CopyNbtStrategy {
 }
 
 /// Copies state properties from dropped block to the item's `BlockStateTag` tag. Fails if the block doesn't match.
-dispatch minecraft:loot_function[copy_state] to struct CopyState {
+dispatch minecraft:loot_function[copy_state]<F, C> to struct CopyState {
 	block: #[id="block"] string,
 	properties: [mcdoc:block_state_keys[[%parent.block]]],
-	...Conditions,
+	...Conditions<C>,
 }
 
 dispatch mcdoc:block_state_keys[%unknown,%none] to string
 
 #[since="1.21.11"]
-dispatch minecraft:loot_function[discard] to struct {
-	...Conditions,
+dispatch minecraft:loot_function[discard]<F, C> to struct {
+	...Conditions<C>,
 }
 
 /// Enchants the item with one randomly-selected enchantment. The level of the enchantment, if applicable, is random.
-dispatch minecraft:loot_function[enchant_randomly] to struct EnchantRandomly {
+dispatch minecraft:loot_function[enchant_randomly]<F, C> to struct EnchantRandomly {
 	/// If omitted, all enchantments applicable to the item are possible
 	#[until="1.21"]
 	enchantments?: [#[id="enchantment"] string],
@@ -148,12 +155,12 @@ dispatch minecraft:loot_function[enchant_randomly] to struct EnchantRandomly {
 	/// Defaults to `false`.
 	#[since="26.1"]
 	include_additional_cost_component?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 /// Enchants the item, with the specified [enchantment level](https://minecraft.wiki/w/Enchanting_mechanics#How_enchantments_are_chosen).
 /// (roughly equivalent to using an enchantment table at that level)
-dispatch minecraft:loot_function[enchant_with_levels] to struct EnchantWithLevels {
+dispatch minecraft:loot_function[enchant_with_levels]<F, C> to struct EnchantWithLevels {
 	/// The levels to enchant this item with.
 	levels: (
 		#[until="1.17"] RandomIntGenerator |
@@ -170,11 +177,11 @@ dispatch minecraft:loot_function[enchant_with_levels] to struct EnchantWithLevel
 	/// Defaults to `false`.
 	#[since="26.1"]
 	include_additional_cost_component?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 /// Converts an empty map into an `explorer map` leading to a nearby generated structure.
-dispatch minecraft:loot_function[exploration_map] to struct ExplorationMap {
+dispatch minecraft:loot_function[exploration_map]<F, C> to struct ExplorationMap {
 	/// Generated structure to locate. Accepts any of the structure types used by the `/locate` command. Defaults to buried treasure.
 	destination?: (
 		#[until="1.19"] string | // TODO: low-priority, this is an enum
@@ -195,7 +202,7 @@ dispatch minecraft:loot_function[exploration_map] to struct ExplorationMap {
 	search_radius?: int,
 	/// Whether to not search in chunks that have already been generated. Defaults to `true`.
 	skip_existing_chunks?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 enum(string) MapDecoration {
@@ -229,45 +236,45 @@ enum(string) MapDecoration {
 }
 
 /// Removes some items from a stack, if there was an explosion. Each item has a chance of 1/explosion radius to be lost.
-dispatch minecraft:loot_function[explosion_decay] to struct {
-	...Conditions,
+dispatch minecraft:loot_function[explosion_decay]<F, C> to struct {
+	...Conditions<C>,
 }
 
 /// Applies loot function(s) to items that match an item predicate.
 #[since="1.20.5"]
-dispatch minecraft:loot_function[filtered] to struct Filtered {
+dispatch minecraft:loot_function[filtered]<F, C> to struct Filtered {
 	/// Item predicate to select items to modify.
 	item_filter: ItemPredicate,
 	/// Loot function to apply to the selected items.
 	#[until="1.21.11"]
-	modifier: (LootFunction | [LootFunction]),
+	modifier: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
 	/// Loot function to apply to the item when `item_filter` passes.
 	#[since="1.21.11"]
-	on_pass?: (LootFunction | [LootFunction]),
+	on_pass?: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
 	/// Loot function to apply to the item when `item_filter` fails.
 	#[since="1.21.11"]
-	on_fail?: (LootFunction | [LootFunction]),
-	...Conditions,
+	on_fail?: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
+	...Conditions<C>,
 }
 
 /// Smelts the item as it would be in a furnace (used in combination with the `entity_properties` condition to cook food from animals on death).
-dispatch minecraft:loot_function[furnace_smelt] to struct {
-	...Conditions,
+dispatch minecraft:loot_function[furnace_smelt]<F, C> to struct {
+	...Conditions<C>,
 }
 
-dispatch minecraft:loot_function[fill_player_head] to struct FillPlayerHead {
+dispatch minecraft:loot_function[fill_player_head]<F, C> to struct FillPlayerHead {
 	/// `this` to use the entity that died or the player that gained the advancement, opened the container, or broke the block.
 	entity: EntityTarget,
-	...Conditions,
+	...Conditions<C>,
 }
 
-dispatch minecraft:loot_function[limit_count] to struct LimitCount {
+dispatch minecraft:loot_function[limit_count]<F, C> to struct LimitCount {
 	/// Limits the count of the item to a range.
 	limit: (
 		#[until="1.17"] IntLimiter |
 		#[since="1.17"] IntRange |
 	),
-	...Conditions,
+	...Conditions<C>,
 }
 
 struct EnchantedCountBase {
@@ -282,39 +289,39 @@ struct EnchantedCountBase {
 
 /// Adjusts the stack size based on the level of the `Looting` enchantment on the `killer` entity's weapon.
 #[until="1.21"]
-dispatch minecraft:loot_function[looting_enchant] to struct LootingEnchant {
+dispatch minecraft:loot_function[looting_enchant]<F, C> to struct LootingEnchant {
 	...EnchantedCountBase,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.21"]
-dispatch minecraft:loot_function[enchanted_count_increase] to struct EnchantedCountIncrease {
+dispatch minecraft:loot_function[enchanted_count_increase]<F, C> to struct EnchantedCountIncrease {
 	...EnchantedCountBase,
 	/// Enchantment that increases yields.
 	enchantment: #[id="enchantment"] string,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20"]
-dispatch minecraft:loot_function[reference] to struct Reference {
+dispatch minecraft:loot_function[reference]<F, C> to struct Reference {
 	/// Item modifier to reference.
 	name: #[id="item_modifier"] string,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.2"]
-dispatch minecraft:loot_function[sequence] to struct Sequence {
+dispatch minecraft:loot_function[sequence]<F, C> to struct Sequence {
 	/// List of functions to apply to this item.
-	functions: [LootFunction],
+	functions: [LootFunctionOf<F, C>],
 	// Intentionally doesn't include conditions, see MC-275648
 }
 
-dispatch minecraft:loot_function[set_attributes] to struct SetAttributes {
+dispatch minecraft:loot_function[set_attributes]<F, C> to struct SetAttributes {
 	/// List of attribute modifiers to apply to this item.
 	modifiers: [AttributeModifier],
 	/// Whether to replace existing attributes (otherwise append to existing). Defaults to `true`.
 	replace?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 struct AttributeModifier {
@@ -345,12 +352,12 @@ struct AttributeModifier {
 }
 
 #[since="1.17"]
-dispatch minecraft:loot_function[set_banner_pattern] to struct SetBannerPattern {
+dispatch minecraft:loot_function[set_banner_pattern]<F, C> to struct SetBannerPattern {
 	/// List of banner pattern layers.
 	patterns: [BannerPatternLayer],
 	/// Whether to add to the banner pattern list.
 	append: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 struct BannerPatternLayer {
@@ -406,22 +413,22 @@ enum(string) BannerPattern {
 }
 
 /// For a container block item's contents.
-dispatch minecraft:loot_function[set_contents] to struct SetContents {
+dispatch minecraft:loot_function[set_contents]<F, C> to struct SetContents {
 	#[since="1.18"] #[until="1.20.5"]
 	type: #[id="block_entity_type"] string,
 	/// Describes target component to be filled with items.
 	#[since="1.20.5"]
 	component: #[id] ContainerComponents,
 	entries: [LootPoolEntry],
-	...Conditions,
+	...Conditions<C>,
 }
 
-dispatch minecraft:loot_function[modify_contents] to struct ModifyContents {
+dispatch minecraft:loot_function[modify_contents]<F, C> to struct ModifyContents {
 	/// Describes target component's items to modify.
 	component: #[id] ContainerComponents,
 	/// Applied to every item inside container.
-	modifier: (LootFunction | [LootFunction]),
-	...Conditions,
+	modifier: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
+	...Conditions<C>,
 }
 
 enum(string) ContainerComponents {
@@ -431,15 +438,15 @@ enum(string) ContainerComponents {
 }
 
 /// Replaces item type of item stack without changing count and components
-dispatch minecraft:loot_function[set_item] to struct SetItem {
+dispatch minecraft:loot_function[set_item]<F, C> to struct SetItem {
 	item: (
 		#[until="1.21.2"] #[id="item"] string |
 		#[since="1.21.2"] #[id(registry="item", exclude=["air"])] string |	
 	),
-	...Conditions,
+	...Conditions<C>,
 }
 
-dispatch minecraft:loot_function[set_count] to struct SetCount {
+dispatch minecraft:loot_function[set_count]<F, C> to struct SetCount {
 	count: (
 		#[until="1.17"] RandomIntGenerator |
 		#[since="1.17"] NumberProvider |
@@ -447,11 +454,11 @@ dispatch minecraft:loot_function[set_count] to struct SetCount {
 	/// Whether to add to the existing count. Defaults to `false`.
 	#[since="1.17"]
 	add?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 /// Sets the durability of applicable items.
-dispatch minecraft:loot_function[set_damage] to struct SetDamage {
+dispatch minecraft:loot_function[set_damage]<F, C> to struct SetDamage {
 	/// Decimal percentage. Can be negative when used in combination with `add`. \
 	/// Clamps to a float between `-1` & `1` (inclusive).
 	damage: (
@@ -461,11 +468,11 @@ dispatch minecraft:loot_function[set_damage] to struct SetDamage {
 	/// Whether to add to the existing damage of the item. Defaults to `false`.
 	#[since="1.17"]
 	add?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.17"]
-dispatch minecraft:loot_function[set_enchantments] to struct SetEnchantments {
+dispatch minecraft:loot_function[set_enchantments]<F, C> to struct SetEnchantments {
 	/// A map of enchantments to levels. Setting an enchantment to `0` removes it from the item. \
 	/// Each level is clamped to a positive integer.
 	enchantments: struct {
@@ -473,22 +480,22 @@ dispatch minecraft:loot_function[set_enchantments] to struct SetEnchantments {
 	},
 	/// Whether to add to the level of each enchantment. Defaults to `false`.
 	add?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.19"]
-dispatch minecraft:loot_function[set_instrument] to struct SetInstrument {
+dispatch minecraft:loot_function[set_instrument]<F, C> to struct SetInstrument {
 	/// Sets the instrument tag for a goat horn.
 	options: (
 		#[until="26.1"] #[id(registry="instrument",tags="required")] string |
 		#[since="26.1"] #[id(registry="instrument",tags="allowed")] string |
 		#[since="26.1"] [#[id="instrument"] string] |
 	),
-	...Conditions,
+	...Conditions<C>,
 }
 
 /// For a container block item's loot table.
-dispatch minecraft:loot_function[set_loot_table] to struct SetLootTable {
+dispatch minecraft:loot_function[set_loot_table]<F, C> to struct SetLootTable {
 	/// The block entity type of the container.
 	#[since="1.18"]
 	type: #[id="block_entity_type"] string,
@@ -496,10 +503,10 @@ dispatch minecraft:loot_function[set_loot_table] to struct SetLootTable {
 	name: #[id="loot_table"] string,
 	/// The container seed to use. Defaults to a random seed.
 	seed?: #[random] long,
-	...Conditions,
+	...Conditions<C>,
 }
 
-dispatch minecraft:loot_function[set_lore] to struct SetLore {
+dispatch minecraft:loot_function[set_lore]<F, C> to struct SetLore {
 	/// The entity used to resolve the text components.
 	entity?: EntityTarget,
 	lore: [Text],
@@ -508,17 +515,17 @@ dispatch minecraft:loot_function[set_lore] to struct SetLore {
 	replace?: boolean,
 	#[since="1.20.5"]
 	...ListOperation,
-	...Conditions,
+	...Conditions<C>,
 }
 
-dispatch minecraft:loot_function[set_name] to struct SetName {
+dispatch minecraft:loot_function[set_name]<F, C> to struct SetName {
 	/// Specifies the entity to act as the target `@s` in the JSON text component.
 	entity?: EntityTarget,
 	name: Text,
 	/// Which name component to set. Defaults to `custom_name`.
 	#[since="1.20.5"]
 	target?: SetNameTarget,
-	...Conditions,
+	...Conditions<C>,
 }
 
 enum(string) SetNameTarget {
@@ -527,25 +534,25 @@ enum(string) SetNameTarget {
 }
 
 #[until="1.20.5"]
-dispatch minecraft:loot_function[set_nbt] to struct SetNbt {
+dispatch minecraft:loot_function[set_nbt]<F, C> to struct SetNbt {
 	tag: #[nbt=minecraft:item[%fallback]] string,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_components] to struct SetComponents {
+dispatch minecraft:loot_function[set_components]<F, C> to struct SetComponents {
 	components: DataComponentPatch,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_custom_data] to struct SetCustomData {
+dispatch minecraft:loot_function[set_custom_data]<F, C> to struct SetCustomData {
 	tag: CustomData,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_custom_model_data] to struct SetCustomModelData {
+dispatch minecraft:loot_function[set_custom_model_data]<F, C> to struct SetCustomModelData {
 	/// Tag that describes the custom model an item will take.
 	/// Used by the `custom_model_data` model overrides predicate.
 	/// Has certain restrictions due to float conversion.
@@ -570,52 +577,52 @@ dispatch minecraft:loot_function[set_custom_model_data] to struct SetCustomModel
 			...ListOperation,
 		},
 	},
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.18"]
-dispatch minecraft:loot_function[set_potion] to struct SetPotion {
+dispatch minecraft:loot_function[set_potion]<F, C> to struct SetPotion {
 	/// The potion identifier.
 	id: #[id="potion"] string,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="26.1"]
-dispatch minecraft:loot_function[set_random_dyes] to struct SetRandomDyes {
+dispatch minecraft:loot_function[set_random_dyes]<F, C> to struct SetRandomDyes {
 	/// Applies specified number of random dyes to the item. \
 	/// For example, one possible outcome of `"number_of_dyes": 2` is `#2C3065`, which is the combination of a blue dye and a black dye. \
 	/// The same dye color can be selected multiple times.
 	number_of_dyes: NumberProvider,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="26.1"]
-dispatch minecraft:loot_function[set_random_potion] to struct SetRandomPotion {
+dispatch minecraft:loot_function[set_random_potion]<F, C> to struct SetRandomPotion {
 	/// Possible potions to select from.
 	/// Defaults to all potions.
 	options?: (#[id(registry="potion",tags="allowed")] string | #[id="potion"] string),
-	...Conditions,
+	...Conditions<C>,
 }
 
-dispatch minecraft:loot_function[set_stew_effect] to struct SetStewEffect {
+dispatch minecraft:loot_function[set_stew_effect]<F, C> to struct SetStewEffect {
 	/// Sets the status effects for suspicious stew.
 	effects?: [StewEffect],
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_fireworks] to struct SetFireworks {
+dispatch minecraft:loot_function[set_fireworks]<F, C> to struct SetFireworks {
 	/// If omitted, the flight duration of the item is left untouched - or set to 0 if the component did not exist before.
 	flight_duration?: int @ 0..255,
 	explosions?: struct FireworkExplosions {
 		values: [minecraft:data_component[firework_explosion]],
 		...ListOperation,
 	},
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_firework_explosion] to struct SetFireworkExplosion {
+dispatch minecraft:loot_function[set_firework_explosion]<F, C> to struct SetFireworkExplosion {
 	/// If omitted, the original shape is kept (or `small_ball` is used if there was no component).
 	shape?: FireworkShape,
 	/// If omitted, the original colors are kept (or `[]` is used if there was no component).
@@ -634,38 +641,38 @@ dispatch minecraft:loot_function[set_firework_explosion] to struct SetFireworkEx
 	trail?: boolean,
 	/// If omitted, the original `has_twinkle` value is kept (or `false` is used if there was no component).
 	twinkle?: boolean,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_book_cover] to struct SetBookCover {
+dispatch minecraft:loot_function[set_book_cover]<F, C> to struct SetBookCover {
 	/// If omitted, the original title is kept (or an empty string is used if there was no component)
 	title?: Filterable<string @ 0..32>,
 	/// If omitted, the original author is kept (or an empty string is used if there was no component)
 	author?: string,
 	/// If omitted, the original generation is kept (or 0 is used if there was no component)
 	generation?: int @ 0..3,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_writable_book_pages] to struct SetWriteableBookPages {
+dispatch minecraft:loot_function[set_writable_book_pages]<F, C> to struct SetWriteableBookPages {
 	/// Sets the pages of a book and quill.
 	pages: [Filterable<string>],
 	...ListOperation,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_written_book_pages] to struct SetWrittenBookPages {
+dispatch minecraft:loot_function[set_written_book_pages]<F, C> to struct SetWrittenBookPages {
 	/// Sets the pages of a written book.
 	pages: [Filterable<Text>],
 	...ListOperation,
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[toggle_tooltips] to struct ToggleTooltips {
+dispatch minecraft:loot_function[toggle_tooltips]<F, C> to struct ToggleTooltips {
 	/// Toggles which tooltips are shown.
 	toggles: struct {
 		#[until="1.21.5"]
@@ -673,13 +680,13 @@ dispatch minecraft:loot_function[toggle_tooltips] to struct ToggleTooltips {
 		#[since="1.21.5"]
 		[#[id="data_component_type"] string]: boolean,
 	},
-	...Conditions,
+	...Conditions<C>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_ominous_bottle_amplifier] to struct SetOminousBottleAmplifier {
+dispatch minecraft:loot_function[set_ominous_bottle_amplifier]<F, C> to struct SetOminousBottleAmplifier {
 	amplifier: NumberProvider,
-	...Conditions,
+	...Conditions<C>,
 }
 
 enum(string) ToggleableDataComponent {

--- a/java/data/loot/mod.mcdoc
+++ b/java/data/loot/mod.mcdoc
@@ -167,21 +167,11 @@ dispatch minecraft:loot_pool_entry[group] to CompositePoolEntry
 /// Executes child entries until the first one that can't run due to conditions.
 dispatch minecraft:loot_pool_entry[sequence] to CompositePoolEntry
 
-struct LootFunction {
-	function: (
-		#[until="1.16"] #[id] LootFunctionType |
-		#[since="1.16"] #[id="loot_function_type"] string |
-	),
-	...minecraft:loot_function[[function]],
-}
+type LootFunction = function::LootFunctionOf<#[id="loot_function_type"] string, #[id="loot_condition_type"] string>
+type NonReferenceLootFunction = function::LootFunctionOf<#[id(registry="loot_function_type",exclude=["reference"])] string, #[id(registry="loot_condition_type",exclude=["reference"])] string>
 
-struct LootCondition {
-	condition: (
-		#[until="1.16"] #[id] LootConditionType |
-		#[since="1.16"] #[id="loot_condition_type"] string |
-	),
-	...minecraft:loot_condition[[condition]],
-}
+type LootCondition = condition::LootConditionOf<#[id="loot_condition_type"] string>
+type NonReferenceLootCondition = condition::LootConditionOf<#[id(registry="loot_condition_type",exclude=["reference"])] string>
 
 // Until 1.16
 enum(string) LootEntryType {

--- a/java/data/predicate.mcdoc
+++ b/java/data/predicate.mcdoc
@@ -5,9 +5,7 @@ type Predicate = (
 	LootCondition |
 	#[since="1.16"] [LootCondition]
 )
-type NonReferencePredicate = (
-	NonReferenceLootCondition |
-	#[since="1.16"] [NonReferenceLootCondition]
-)
+// Since 1.21
+type NonReferencePredicate = (NonReferenceLootCondition | [NonReferenceLootCondition])
 
 dispatch minecraft:resource[predicate] to Predicate

--- a/java/data/predicate.mcdoc
+++ b/java/data/predicate.mcdoc
@@ -1,7 +1,13 @@
 use super::loot::LootCondition
+use super::loot::NonReferenceLootCondition
 
 type Predicate = (
 	LootCondition |
 	#[since="1.16"] [LootCondition]
 )
+type NonReferencePredicate = (
+	NonReferenceLootCondition |
+	#[since="1.16"] [NonReferenceLootCondition]
+)
+
 dispatch minecraft:resource[predicate] to Predicate

--- a/java/data/villager_trade.mcdoc
+++ b/java/data/villager_trade.mcdoc
@@ -1,6 +1,6 @@
 use ::java::data::util::NumberProvider
-use ::java::data::predicate::Predicate
-use ::java::data::item_modifier::ItemModifier
+use ::java::data::predicate::NonReferencePredicate
+use ::java::data::item_modifier::NonReferenceItemModifier
 use ::java::world::item::ItemStackTemplate
 use ::java::world::item::TradeCost
 
@@ -18,7 +18,7 @@ dispatch minecraft:resource[villager_trade] to struct VillagerTrade {
 	/// Does **not** support `reference` item modifier. \
 	/// Some modifiers can affect the price through the `additional_trade_cost` transient component. \
 	/// The `additional_trade_cost` component is not saved on the offered item.
-	given_item_modifiers?: [ItemModifier],
+	given_item_modifiers?: [NonReferenceItemModifier],
 	/// Maximum number of uses of this trade before the villager has to restock. Defaults to `4`. \
 	/// Clamps to a positive integer.
 	max_uses?: NumberProvider,
@@ -30,7 +30,7 @@ dispatch minecraft:resource[villager_trade] to struct VillagerTrade {
 	xp?: NumberProvider,
 	/// Check whether the trade should be offered by the merchant. \
 	/// Does **not** support the `reference` predicate.
-	merchant_predicate?: Predicate,
+	merchant_predicate?: NonReferencePredicate,
 	// TODO: Provide a better explanation
 	// The "stored_enchantments" component on any item can affect the price
 	/// If the offered enchanted book has the specified enchantments, the price will be affected by doubling the `additional_trade_cost` transient component.


### PR DESCRIPTION
- Rewrite loot conditions and loot functions with type generics.
- Disallow `reference` predicate in enchantment effects.
- Disallow `reference` predicate and `reference` item modifier in villager trade.
- Type aliases `LootFunction` and `LootCondition` should work in the same way as before.
