### PR TITLE
🐛 Disallow loot table/slot source reference in "experimental" resources

### DIFF
--- a/java/data/loot/condition.mcdoc
+++ b/java/data/loot/condition.mcdoc
@@ -8,53 +8,53 @@ use super::super::advancement::predicate::EntityPredicate
 use super::super::advancement::predicate::LocationPredicate
 use super::super::advancement::predicate::DamageSourcePredicate
 
-type LootConditionOf<C> = struct {
+type LootConditionOf<CT> = struct {
 	condition: (
 		#[until="1.16"] #[id] super::LootConditionType |
-		#[since="1.16"] C |
+		#[since="1.16"] CT |
 	),
-	...minecraft:loot_condition[[condition]]<C>,
+	...minecraft:loot_condition[[condition]]<CT>,
 }
 
 /// Whether any condition within a list passes.
 #[until="1.20"]
-dispatch minecraft:loot_condition[alternative]<C> to struct Alternative {
-	terms: [LootConditionOf<C>],
+dispatch minecraft:loot_condition[alternative]<CT> to struct Alternative {
+	terms: [LootConditionOf<CT>],
 }
 
 #[since="1.20"]
-dispatch minecraft:loot_condition[any_of]<C> to struct AnyOf {
+dispatch minecraft:loot_condition[any_of]<CT> to struct AnyOf {
 	/// Passes when any of these conditions pass.
-	terms: [LootConditionOf<C>],
+	terms: [LootConditionOf<CT>],
 }
 
 #[since="1.20"]
-dispatch minecraft:loot_condition[all_of]<C> to struct AllOf {
+dispatch minecraft:loot_condition[all_of]<CT> to struct AllOf {
 	/// Passes when all of these conditions pass.
-	terms: [LootConditionOf<C>],
+	terms: [LootConditionOf<CT>],
 }
 
-dispatch minecraft:loot_condition[block_state_property]<C> to struct BlockStateProperty {
+dispatch minecraft:loot_condition[block_state_property]<CT> to struct BlockStateProperty {
 	block: #[id="block"] string,
 	// TODO: was this optional in 1.20.2 and before? (wasn't codecified yet)
 	properties?: mcdoc:block_states[[block]],
 }
 
-dispatch minecraft:loot_condition[damage_source_properties]<C> to struct DamageSourceProperties {
+dispatch minecraft:loot_condition[damage_source_properties]<CT> to struct DamageSourceProperties {
 	predicate: DamageSourcePredicate,
 }
 
 /// Requires the "Enchantment Active" parameter to exist in the context, which currently means it only works in Enchantment conditions.
-dispatch minecraft:loot_condition[enchantment_active_check]<C> to struct EnchantmentActiveCheck {
+dispatch minecraft:loot_condition[enchantment_active_check]<CT> to struct EnchantmentActiveCheck {
 	active: boolean,
 }
 
-dispatch minecraft:loot_condition[entity_properties]<C> to struct EntityProperties {
+dispatch minecraft:loot_condition[entity_properties]<CT> to struct EntityProperties {
 	entity: EntityTarget,
 	predicate: EntityPredicate,
 }
 
-dispatch minecraft:loot_condition[entity_scores]<C> to struct EntityScores {
+dispatch minecraft:loot_condition[entity_scores]<CT> to struct EntityScores {
 	entity: EntityTarget,
 	scores: struct {
 		[#[objective] string]: (
@@ -65,32 +65,32 @@ dispatch minecraft:loot_condition[entity_scores]<C> to struct EntityScores {
 }
 
 #[since="26.1"]
-dispatch minecraft:loot_condition[environment_attribute_check]<C> to struct EnvironmentAttributeCheck {
+dispatch minecraft:loot_condition[environment_attribute_check]<CT> to struct EnvironmentAttributeCheck {
 	attribute: #[id="environment_attribute"] string,
 	value: minecraft:environment_attribute[[attribute]][value],
 }
 
 /// Whether a condition does not pass.
-dispatch minecraft:loot_condition[inverted]<C> to struct Inverted {
-	term: LootConditionOf<C>,
+dispatch minecraft:loot_condition[inverted]<CT> to struct Inverted {
+	term: LootConditionOf<CT>,
 }
 
-dispatch minecraft:loot_condition[killed_by_player]<C> to struct KilledByPlayer {
+dispatch minecraft:loot_condition[killed_by_player]<CT> to struct KilledByPlayer {
 	inverse?: boolean,
 }
 
-dispatch minecraft:loot_condition[location_check]<C> to struct LocationCheck {
+dispatch minecraft:loot_condition[location_check]<CT> to struct LocationCheck {
 	offsetX?: int,
 	offsetY?: int,
 	offsetZ?: int,
 	predicate: LocationPredicate,
 }
 
-dispatch minecraft:loot_condition[match_tool]<C> to struct MatchTool {
+dispatch minecraft:loot_condition[match_tool]<CT> to struct MatchTool {
 	predicate: ItemPredicate,
 }
 
-dispatch minecraft:loot_condition[random_chance]<C> to struct RandomChance {
+dispatch minecraft:loot_condition[random_chance]<CT> to struct RandomChance {
 	/// Clamps to a float between `0` & `1` (inclusive).
 	chance: (
 		#[until="1.21"] float @ 0..1 |
@@ -99,32 +99,32 @@ dispatch minecraft:loot_condition[random_chance]<C> to struct RandomChance {
 }
 
 #[until="1.21"]
-dispatch minecraft:loot_condition[random_chance_with_looting]<C> to struct RandomChanceWithLooting {
+dispatch minecraft:loot_condition[random_chance_with_looting]<CT> to struct RandomChanceWithLooting {
 	chance: float @ 0..1,
 	/// Looting adjustment to the base success rate. Formula is `chance + (looting_level * looting_multiplier)` .
 	looting_multiplier: float,
 }
 
 #[since="1.21"]
-dispatch minecraft:loot_condition[random_chance_with_enchanted_bonus]<C> to struct RandomChanceWithEnchantedBonus {
+dispatch minecraft:loot_condition[random_chance_with_enchanted_bonus]<CT> to struct RandomChanceWithEnchantedBonus {
 	unenchanted_chance: float @ 0..1,
 	enchanted_chance: LevelBasedValue,
 	enchantment: #[id="enchantment"] string,
 }
 
 /// Whether another predicate passes.
-dispatch minecraft:loot_condition[reference]<C> to struct Reference {
+dispatch minecraft:loot_condition[reference]<CT> to struct Reference {
 	/// A cyclic reference causes a parsing failure.
 	name: #[id="predicate"] string,
 }
 
-dispatch minecraft:loot_condition[table_bonus]<C> to struct TableBonus {
+dispatch minecraft:loot_condition[table_bonus]<CT> to struct TableBonus {
 	enchantment: #[id="enchantment"] string,
 	/// Probabilities for each enchantment level
 	chances: [float @ 0..1],
 }
 
-dispatch minecraft:loot_condition[time_check]<C> to struct TimeCheck {
+dispatch minecraft:loot_condition[time_check]<CT> to struct TimeCheck {
 	/// The world clock to check.
 	#[since="26.1"]
 	clock: #[id="world_clock"] string,
@@ -139,14 +139,14 @@ dispatch minecraft:loot_condition[time_check]<C> to struct TimeCheck {
 }
 
 #[since="1.17"]
-dispatch minecraft:loot_condition[value_check]<C> to struct ValueCheck {
+dispatch minecraft:loot_condition[value_check]<CT> to struct ValueCheck {
 	/// Clamps to an integer.
 	value: NumberProvider,
 	/// Passes when `value` is within this range.
 	range: IntRange,
 }
 
-dispatch minecraft:loot_condition[weather_check]<C> to struct WeatherCheck {
+dispatch minecraft:loot_condition[weather_check]<CT> to struct WeatherCheck {
 	raining?: boolean,
 	thundering?: boolean,
 }

--- a/java/data/loot/function.mcdoc
+++ b/java/data/loot/function.mcdoc
@@ -21,23 +21,23 @@ use ::java::world::component::DataComponentPatch
 use ::java::world::component::CustomData
 use ::java::world::component::item::FireworkShape
 
-type Conditions<C> = struct {
-	conditions?: [LootConditionOf<C>],
+type Conditions<CT> = struct {
+	conditions?: [LootConditionOf<CT>],
 }
 
-type LootFunctionOf<F, C> = struct {
+type LootFunctionOf<FT, CT, LRef, ST> = struct {
 	function: (
 		#[until="1.16"] #[id] super::LootFunctionType |
-		#[since="1.16"] F |
+		#[since="1.16"] FT |
 	),
-	...minecraft:loot_function[[function]]<F, C>,
+	...minecraft:loot_function[[function]]<FT, CT, LRef, ST>,
 }
 
-dispatch minecraft:loot_function[apply_bonus]<F, C> to struct ApplyBonus {
+dispatch minecraft:loot_function[apply_bonus]<FT, CT, LRef, ST> to struct ApplyBonus {
 	enchantment: #[id="enchantment"] string,
 	formula: #[id] ApplyBonusFormula,
 	...minecraft:apply_bonus_formula[[formula]],
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 enum(string) ApplyBonusFormula {
@@ -65,13 +65,13 @@ dispatch minecraft:apply_bonus_formula[binomial_with_bonus_count] to struct Bino
 }
 
 /// Copies `CustomName` tag from an entity or block entity into the item's `custom_name` component.
-dispatch minecraft:loot_function[copy_name]<F, C> to struct CopyName {
+dispatch minecraft:loot_function[copy_name]<FT, CT, LRef, ST> to struct CopyName {
 	source: (
 		#[until="1.21.9"] CopyNameSource |
 		#[since="1.21.9"] EntityTarget | 
 		#[since="1.21.9"] BlockEntityTarget |
 	),
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 enum(string) CopyNameSource {
@@ -83,7 +83,7 @@ enum(string) CopyNameSource {
 	BlockEntity = "block_entity",
 }
 
-type CopyNbt<C> = struct {
+type CopyNbt<CT> = struct {
 	source: NbtProvider,
 	ops: [(struct CopyNbtOperation {
 		source: #[nbt_path] string, // TODO
@@ -93,17 +93,17 @@ type CopyNbt<C> = struct {
 		),
 		op: CopyNbtStrategy
 	})],
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[until="1.20.5"]
-dispatch minecraft:loot_function[copy_nbt]<F, C> to CopyNbt<C>
+dispatch minecraft:loot_function[copy_nbt]<FT, CT, LRef, ST> to CopyNbt<CT>
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[copy_custom_data]<F, C> to CopyNbt<C>
+dispatch minecraft:loot_function[copy_custom_data]<FT, CT, LRef, ST> to CopyNbt<CT>
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[copy_components]<F, C> to struct CopyComponents {
+dispatch minecraft:loot_function[copy_components]<FT, CT, LRef, ST> to struct CopyComponents {
 	source: (
 		BlockEntityTarget |
 		#[since="1.21.9"] EntityTarget |
@@ -113,7 +113,7 @@ dispatch minecraft:loot_function[copy_components]<F, C> to struct CopyComponents
 	include?: [#[id="data_component_type"] string],
 	/// Defaults to none.
 	exclude?: [#[id="data_component_type"] string],
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 enum(string) CopyNbtStrategy {
@@ -126,21 +126,21 @@ enum(string) CopyNbtStrategy {
 }
 
 /// Copies state properties from dropped block to the item's `BlockStateTag` tag. Fails if the block doesn't match.
-dispatch minecraft:loot_function[copy_state]<F, C> to struct CopyState {
+dispatch minecraft:loot_function[copy_state]<FT, CT, LRef, ST> to struct CopyState {
 	block: #[id="block"] string,
 	properties: [mcdoc:block_state_keys[[%parent.block]]],
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 dispatch mcdoc:block_state_keys[%unknown,%none] to string
 
 #[since="1.21.11"]
-dispatch minecraft:loot_function[discard]<F, C> to struct {
-	...Conditions<C>,
+dispatch minecraft:loot_function[discard]<FT, CT, LRef, ST> to struct {
+	...Conditions<CT>,
 }
 
 /// Enchants the item with one randomly-selected enchantment. The level of the enchantment, if applicable, is random.
-dispatch minecraft:loot_function[enchant_randomly]<F, C> to struct EnchantRandomly {
+dispatch minecraft:loot_function[enchant_randomly]<FT, CT, LRef, ST> to struct EnchantRandomly {
 	/// If omitted, all enchantments applicable to the item are possible
 	#[until="1.21"]
 	enchantments?: [#[id="enchantment"] string],
@@ -155,12 +155,12 @@ dispatch minecraft:loot_function[enchant_randomly]<F, C> to struct EnchantRandom
 	/// Defaults to `false`.
 	#[since="26.1"]
 	include_additional_cost_component?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 /// Enchants the item, with the specified [enchantment level](https://minecraft.wiki/w/Enchanting_mechanics#How_enchantments_are_chosen).
 /// (roughly equivalent to using an enchantment table at that level)
-dispatch minecraft:loot_function[enchant_with_levels]<F, C> to struct EnchantWithLevels {
+dispatch minecraft:loot_function[enchant_with_levels]<FT, CT, LRef, ST> to struct EnchantWithLevels {
 	/// The levels to enchant this item with.
 	levels: (
 		#[until="1.17"] RandomIntGenerator |
@@ -177,11 +177,11 @@ dispatch minecraft:loot_function[enchant_with_levels]<F, C> to struct EnchantWit
 	/// Defaults to `false`.
 	#[since="26.1"]
 	include_additional_cost_component?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 /// Converts an empty map into an `explorer map` leading to a nearby generated structure.
-dispatch minecraft:loot_function[exploration_map]<F, C> to struct ExplorationMap {
+dispatch minecraft:loot_function[exploration_map]<FT, CT, LRef, ST> to struct ExplorationMap {
 	/// Generated structure to locate. Accepts any of the structure types used by the `/locate` command. Defaults to buried treasure.
 	destination?: (
 		#[until="1.19"] string | // TODO: low-priority, this is an enum
@@ -202,7 +202,7 @@ dispatch minecraft:loot_function[exploration_map]<F, C> to struct ExplorationMap
 	search_radius?: int,
 	/// Whether to not search in chunks that have already been generated. Defaults to `true`.
 	skip_existing_chunks?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 enum(string) MapDecoration {
@@ -236,45 +236,45 @@ enum(string) MapDecoration {
 }
 
 /// Removes some items from a stack, if there was an explosion. Each item has a chance of 1/explosion radius to be lost.
-dispatch minecraft:loot_function[explosion_decay]<F, C> to struct {
-	...Conditions<C>,
+dispatch minecraft:loot_function[explosion_decay]<FT, CT, LRef, ST> to struct {
+	...Conditions<CT>,
 }
 
 /// Applies loot function(s) to items that match an item predicate.
 #[since="1.20.5"]
-dispatch minecraft:loot_function[filtered]<F, C> to struct Filtered {
+dispatch minecraft:loot_function[filtered]<FT, CT, LRef, ST> to struct Filtered {
 	/// Item predicate to select items to modify.
 	item_filter: ItemPredicate,
 	/// Loot function to apply to the selected items.
 	#[until="1.21.11"]
-	modifier: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
+	modifier: (LootFunctionOf<FT, CT, LRef, ST> | [LootFunctionOf<FT, CT, LRef, ST>]),
 	/// Loot function to apply to the item when `item_filter` passes.
 	#[since="1.21.11"]
-	on_pass?: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
+	on_pass?: (LootFunctionOf<FT, CT, LRef, ST> | [LootFunctionOf<FT, CT, LRef, ST>]),
 	/// Loot function to apply to the item when `item_filter` fails.
 	#[since="1.21.11"]
-	on_fail?: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
-	...Conditions<C>,
+	on_fail?: (LootFunctionOf<FT, CT, LRef, ST> | [LootFunctionOf<FT, CT, LRef, ST>]),
+	...Conditions<CT>,
 }
 
 /// Smelts the item as it would be in a furnace (used in combination with the `entity_properties` condition to cook food from animals on death).
-dispatch minecraft:loot_function[furnace_smelt]<F, C> to struct {
-	...Conditions<C>,
+dispatch minecraft:loot_function[furnace_smelt]<FT, CT, LRef, ST> to struct {
+	...Conditions<CT>,
 }
 
-dispatch minecraft:loot_function[fill_player_head]<F, C> to struct FillPlayerHead {
+dispatch minecraft:loot_function[fill_player_head]<FT, CT, LRef, ST> to struct FillPlayerHead {
 	/// `this` to use the entity that died or the player that gained the advancement, opened the container, or broke the block.
 	entity: EntityTarget,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
-dispatch minecraft:loot_function[limit_count]<F, C> to struct LimitCount {
+dispatch minecraft:loot_function[limit_count]<FT, CT, LRef, ST> to struct LimitCount {
 	/// Limits the count of the item to a range.
 	limit: (
 		#[until="1.17"] IntLimiter |
 		#[since="1.17"] IntRange |
 	),
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 struct EnchantedCountBase {
@@ -289,39 +289,39 @@ struct EnchantedCountBase {
 
 /// Adjusts the stack size based on the level of the `Looting` enchantment on the `killer` entity's weapon.
 #[until="1.21"]
-dispatch minecraft:loot_function[looting_enchant]<F, C> to struct LootingEnchant {
+dispatch minecraft:loot_function[looting_enchant]<FT, CT, LRef, ST> to struct LootingEnchant {
 	...EnchantedCountBase,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.21"]
-dispatch minecraft:loot_function[enchanted_count_increase]<F, C> to struct EnchantedCountIncrease {
+dispatch minecraft:loot_function[enchanted_count_increase]<FT, CT, LRef, ST> to struct EnchantedCountIncrease {
 	...EnchantedCountBase,
 	/// Enchantment that increases yields.
 	enchantment: #[id="enchantment"] string,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20"]
-dispatch minecraft:loot_function[reference]<F, C> to struct Reference {
+dispatch minecraft:loot_function[reference]<FT, CT, LRef, ST> to struct Reference {
 	/// Item modifier to reference.
 	name: #[id="item_modifier"] string,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.2"]
-dispatch minecraft:loot_function[sequence]<F, C> to struct Sequence {
+dispatch minecraft:loot_function[sequence]<FT, CT, LRef, ST> to struct Sequence {
 	/// List of functions to apply to this item.
-	functions: [LootFunctionOf<F, C>],
+	functions: [LootFunctionOf<FT, CT, LRef, ST>],
 	// Intentionally doesn't include conditions, see MC-275648
 }
 
-dispatch minecraft:loot_function[set_attributes]<F, C> to struct SetAttributes {
+dispatch minecraft:loot_function[set_attributes]<FT, CT, LRef, ST> to struct SetAttributes {
 	/// List of attribute modifiers to apply to this item.
 	modifiers: [AttributeModifier],
 	/// Whether to replace existing attributes (otherwise append to existing). Defaults to `true`.
 	replace?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 struct AttributeModifier {
@@ -352,12 +352,12 @@ struct AttributeModifier {
 }
 
 #[since="1.17"]
-dispatch minecraft:loot_function[set_banner_pattern]<F, C> to struct SetBannerPattern {
+dispatch minecraft:loot_function[set_banner_pattern]<FT, CT, LRef, ST> to struct SetBannerPattern {
 	/// List of banner pattern layers.
 	patterns: [BannerPatternLayer],
 	/// Whether to add to the banner pattern list.
 	append: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 struct BannerPatternLayer {
@@ -413,23 +413,22 @@ enum(string) BannerPattern {
 }
 
 /// For a container block item's contents.
-dispatch minecraft:loot_function[set_contents]<F, C> to struct SetContents {
+dispatch minecraft:loot_function[set_contents]<FT, CT, LRef, ST> to struct SetContents {
 	#[since="1.18"] #[until="1.20.5"]
 	type: #[id="block_entity_type"] string,
 	/// Describes target component to be filled with items.
 	#[since="1.20.5"]
 	component: #[id] ContainerComponents,
-	// TODO: disallow reference here
-	entries: [LootPoolEntry],
-	...Conditions<C>,
+	entries: [LootPoolEntry<FT, CT, LRef, ST>],
+	...Conditions<CT>,
 }
 
-dispatch minecraft:loot_function[modify_contents]<F, C> to struct ModifyContents {
+dispatch minecraft:loot_function[modify_contents]<FT, CT, LRef, ST> to struct ModifyContents {
 	/// Describes target component's items to modify.
 	component: #[id] ContainerComponents,
 	/// Applied to every item inside container.
-	modifier: (LootFunctionOf<F, C> | [LootFunctionOf<F, C>]),
-	...Conditions<C>,
+	modifier: (LootFunctionOf<FT, CT, LRef, ST> | [LootFunctionOf<FT, CT, LRef, ST>]),
+	...Conditions<CT>,
 }
 
 enum(string) ContainerComponents {
@@ -439,15 +438,15 @@ enum(string) ContainerComponents {
 }
 
 /// Replaces item type of item stack without changing count and components
-dispatch minecraft:loot_function[set_item]<F, C> to struct SetItem {
+dispatch minecraft:loot_function[set_item]<FT, CT, LRef, ST> to struct SetItem {
 	item: (
 		#[until="1.21.2"] #[id="item"] string |
 		#[since="1.21.2"] #[id(registry="item", exclude=["air"])] string |	
 	),
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
-dispatch minecraft:loot_function[set_count]<F, C> to struct SetCount {
+dispatch minecraft:loot_function[set_count]<FT, CT, LRef, ST> to struct SetCount {
 	count: (
 		#[until="1.17"] RandomIntGenerator |
 		#[since="1.17"] NumberProvider |
@@ -455,11 +454,11 @@ dispatch minecraft:loot_function[set_count]<F, C> to struct SetCount {
 	/// Whether to add to the existing count. Defaults to `false`.
 	#[since="1.17"]
 	add?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 /// Sets the durability of applicable items.
-dispatch minecraft:loot_function[set_damage]<F, C> to struct SetDamage {
+dispatch minecraft:loot_function[set_damage]<FT, CT, LRef, ST> to struct SetDamage {
 	/// Decimal percentage. Can be negative when used in combination with `add`. \
 	/// Clamps to a float between `-1` & `1` (inclusive).
 	damage: (
@@ -469,11 +468,11 @@ dispatch minecraft:loot_function[set_damage]<F, C> to struct SetDamage {
 	/// Whether to add to the existing damage of the item. Defaults to `false`.
 	#[since="1.17"]
 	add?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.17"]
-dispatch minecraft:loot_function[set_enchantments]<F, C> to struct SetEnchantments {
+dispatch minecraft:loot_function[set_enchantments]<FT, CT, LRef, ST> to struct SetEnchantments {
 	/// A map of enchantments to levels. Setting an enchantment to `0` removes it from the item. \
 	/// Each level is clamped to a positive integer.
 	enchantments: struct {
@@ -481,22 +480,22 @@ dispatch minecraft:loot_function[set_enchantments]<F, C> to struct SetEnchantmen
 	},
 	/// Whether to add to the level of each enchantment. Defaults to `false`.
 	add?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.19"]
-dispatch minecraft:loot_function[set_instrument]<F, C> to struct SetInstrument {
+dispatch minecraft:loot_function[set_instrument]<FT, CT, LRef, ST> to struct SetInstrument {
 	/// Sets the instrument tag for a goat horn.
 	options: (
 		#[until="26.1"] #[id(registry="instrument",tags="required")] string |
 		#[since="26.1"] #[id(registry="instrument",tags="allowed")] string |
 		#[since="26.1"] [#[id="instrument"] string] |
 	),
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 /// For a container block item's loot table.
-dispatch minecraft:loot_function[set_loot_table]<F, C> to struct SetLootTable {
+dispatch minecraft:loot_function[set_loot_table]<FT, CT, LRef, ST> to struct SetLootTable {
 	/// The block entity type of the container.
 	#[since="1.18"]
 	type: #[id="block_entity_type"] string,
@@ -504,10 +503,10 @@ dispatch minecraft:loot_function[set_loot_table]<F, C> to struct SetLootTable {
 	name: #[id="loot_table"] string,
 	/// The container seed to use. Defaults to a random seed.
 	seed?: #[random] long,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
-dispatch minecraft:loot_function[set_lore]<F, C> to struct SetLore {
+dispatch minecraft:loot_function[set_lore]<FT, CT, LRef, ST> to struct SetLore {
 	/// The entity used to resolve the text components.
 	entity?: EntityTarget,
 	lore: [Text],
@@ -516,17 +515,17 @@ dispatch minecraft:loot_function[set_lore]<F, C> to struct SetLore {
 	replace?: boolean,
 	#[since="1.20.5"]
 	...ListOperation,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
-dispatch minecraft:loot_function[set_name]<F, C> to struct SetName {
+dispatch minecraft:loot_function[set_name]<FT, CT, LRef, ST> to struct SetName {
 	/// Specifies the entity to act as the target `@s` in the JSON text component.
 	entity?: EntityTarget,
 	name: Text,
 	/// Which name component to set. Defaults to `custom_name`.
 	#[since="1.20.5"]
 	target?: SetNameTarget,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 enum(string) SetNameTarget {
@@ -535,25 +534,25 @@ enum(string) SetNameTarget {
 }
 
 #[until="1.20.5"]
-dispatch minecraft:loot_function[set_nbt]<F, C> to struct SetNbt {
+dispatch minecraft:loot_function[set_nbt]<FT, CT, LRef, ST> to struct SetNbt {
 	tag: #[nbt=minecraft:item[%fallback]] string,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_components]<F, C> to struct SetComponents {
+dispatch minecraft:loot_function[set_components]<FT, CT, LRef, ST> to struct SetComponents {
 	components: DataComponentPatch,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_custom_data]<F, C> to struct SetCustomData {
+dispatch minecraft:loot_function[set_custom_data]<FT, CT, LRef, ST> to struct SetCustomData {
 	tag: CustomData,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_custom_model_data]<F, C> to struct SetCustomModelData {
+dispatch minecraft:loot_function[set_custom_model_data]<FT, CT, LRef, ST> to struct SetCustomModelData {
 	/// Tag that describes the custom model an item will take.
 	/// Used by the `custom_model_data` model overrides predicate.
 	/// Has certain restrictions due to float conversion.
@@ -578,52 +577,52 @@ dispatch minecraft:loot_function[set_custom_model_data]<F, C> to struct SetCusto
 			...ListOperation,
 		},
 	},
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.18"]
-dispatch minecraft:loot_function[set_potion]<F, C> to struct SetPotion {
+dispatch minecraft:loot_function[set_potion]<FT, CT, LRef, ST> to struct SetPotion {
 	/// The potion identifier.
 	id: #[id="potion"] string,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="26.1"]
-dispatch minecraft:loot_function[set_random_dyes]<F, C> to struct SetRandomDyes {
+dispatch minecraft:loot_function[set_random_dyes]<FT, CT, LRef, ST> to struct SetRandomDyes {
 	/// Applies specified number of random dyes to the item. \
 	/// For example, one possible outcome of `"number_of_dyes": 2` is `#2C3065`, which is the combination of a blue dye and a black dye. \
 	/// The same dye color can be selected multiple times.
 	number_of_dyes: NumberProvider,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="26.1"]
-dispatch minecraft:loot_function[set_random_potion]<F, C> to struct SetRandomPotion {
+dispatch minecraft:loot_function[set_random_potion]<FT, CT, LRef, ST> to struct SetRandomPotion {
 	/// Possible potions to select from.
 	/// Defaults to all potions.
 	options?: (#[id(registry="potion",tags="allowed")] string | #[id="potion"] string),
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
-dispatch minecraft:loot_function[set_stew_effect]<F, C> to struct SetStewEffect {
+dispatch minecraft:loot_function[set_stew_effect]<FT, CT, LRef, ST> to struct SetStewEffect {
 	/// Sets the status effects for suspicious stew.
 	effects?: [StewEffect],
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_fireworks]<F, C> to struct SetFireworks {
+dispatch minecraft:loot_function[set_fireworks]<FT, CT, LRef, ST> to struct SetFireworks {
 	/// If omitted, the flight duration of the item is left untouched - or set to 0 if the component did not exist before.
 	flight_duration?: int @ 0..255,
 	explosions?: struct FireworkExplosions {
 		values: [minecraft:data_component[firework_explosion]],
 		...ListOperation,
 	},
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_firework_explosion]<F, C> to struct SetFireworkExplosion {
+dispatch minecraft:loot_function[set_firework_explosion]<FT, CT, LRef, ST> to struct SetFireworkExplosion {
 	/// If omitted, the original shape is kept (or `small_ball` is used if there was no component).
 	shape?: FireworkShape,
 	/// If omitted, the original colors are kept (or `[]` is used if there was no component).
@@ -642,38 +641,38 @@ dispatch minecraft:loot_function[set_firework_explosion]<F, C> to struct SetFire
 	trail?: boolean,
 	/// If omitted, the original `has_twinkle` value is kept (or `false` is used if there was no component).
 	twinkle?: boolean,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_book_cover]<F, C> to struct SetBookCover {
+dispatch minecraft:loot_function[set_book_cover]<FT, CT, LRef, ST> to struct SetBookCover {
 	/// If omitted, the original title is kept (or an empty string is used if there was no component)
 	title?: Filterable<string @ 0..32>,
 	/// If omitted, the original author is kept (or an empty string is used if there was no component)
 	author?: string,
 	/// If omitted, the original generation is kept (or 0 is used if there was no component)
 	generation?: int @ 0..3,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_writable_book_pages]<F, C> to struct SetWriteableBookPages {
+dispatch minecraft:loot_function[set_writable_book_pages]<FT, CT, LRef, ST> to struct SetWriteableBookPages {
 	/// Sets the pages of a book and quill.
 	pages: [Filterable<string>],
 	...ListOperation,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_written_book_pages]<F, C> to struct SetWrittenBookPages {
+dispatch minecraft:loot_function[set_written_book_pages]<FT, CT, LRef, ST> to struct SetWrittenBookPages {
 	/// Sets the pages of a written book.
 	pages: [Filterable<Text>],
 	...ListOperation,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[toggle_tooltips]<F, C> to struct ToggleTooltips {
+dispatch minecraft:loot_function[toggle_tooltips]<FT, CT, LRef, ST> to struct ToggleTooltips {
 	/// Toggles which tooltips are shown.
 	toggles: struct {
 		#[until="1.21.5"]
@@ -681,13 +680,13 @@ dispatch minecraft:loot_function[toggle_tooltips]<F, C> to struct ToggleTooltips
 		#[since="1.21.5"]
 		[#[id="data_component_type"] string]: boolean,
 	},
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 #[since="1.20.5"]
-dispatch minecraft:loot_function[set_ominous_bottle_amplifier]<F, C> to struct SetOminousBottleAmplifier {
+dispatch minecraft:loot_function[set_ominous_bottle_amplifier]<FT, CT, LRef, ST> to struct SetOminousBottleAmplifier {
 	amplifier: NumberProvider,
-	...Conditions<C>,
+	...Conditions<CT>,
 }
 
 enum(string) ToggleableDataComponent {

--- a/java/data/loot/mod.mcdoc
+++ b/java/data/loot/mod.mcdoc
@@ -1,13 +1,28 @@
-use ::java::data::slot_source::SlotSource
+use ::java::data::slot_source::SlotSourceOf
 use ::java::util::text::Text
 use super::util::MinMaxBounds
 use super::util::NumberProvider
 use super::util::RandomIntGenerator
+use function::LootFunctionOf
+use condition::LootConditionOf
 
-dispatch minecraft:resource[loot_table] to struct LootTable {
+dispatch minecraft:resource[loot_table] to LootTable
+
+type LootTable = LootTableOf<
+	#[id="loot_function_type"] string,
+	#[id="loot_condition_type"] string,
+	#[id="loot_table"] string,
+	#[id="slot_source"] string
+>
+
+// FT: loot function type
+// CT: loot condition type
+// LRef: loot table ID or empty union
+// ST: slot source type
+type LootTableOf<FT, CT, LRef, ST> = struct {
 	type?: #[id] LootContextType,
-	pools?: [LootPool],
-	functions?: [LootFunction],
+	pools?: [LootPool<FT, CT, LRef, ST>],
+	functions?: [LootFunctionOf<FT, CT, LRef, ST>],
 	#[since="1.20"]
 	random_sequence?: #[id(registry="random_sequence",definition=true)] string,
 }
@@ -73,7 +88,7 @@ enum(string) EntityTarget {
 type BlockEntityTarget = "block_entity"
 type ItemStackTarget = "tool"
 
-struct LootPool {
+type LootPool<FT, CT, LRef, ST> = struct {
 	rolls: (
 		#[until="1.17"] RandomIntGenerator |
 		#[since="1.17"] NumberProvider |
@@ -82,36 +97,36 @@ struct LootPool {
 		#[until="1.17"] MinMaxBounds<float> |
 		#[since="1.17"] NumberProvider |
 	),
-	entries: [LootPoolEntry],
-	functions?: [LootFunction],
-	conditions?: [LootCondition],
+	entries: [LootPoolEntry<FT, CT, LRef, ST>],
+	functions?: [LootFunctionOf<FT, CT, LRef, ST>],
+	conditions?: [LootConditionOf<CT>],
 }
 
-struct LootPoolEntry {
+type LootPoolEntry<FT, CT, LRef, ST> = struct {
 	type: (
 		#[until="1.16"] #[id] LootEntryType |
 		#[since="1.16"] #[id="loot_pool_entry_type"] string |
 	),
-	...minecraft:loot_pool_entry[[type]],
+	...minecraft:loot_pool_entry[[type]]<FT, CT, LRef, ST>,
 }
 
-struct LootPoolEntryBase {
-	conditions?: [LootCondition],
+type LootPoolEntryBase<CT> = struct {
+	conditions?: [LootConditionOf<CT>],
 }
 
-struct SingletonPoolEntry {
+type SingletonPoolEntry<FT, CT, LRef, ST> = struct {
 	weight?: int @ 1..,
 	quality?: int,
-	...LootPoolEntryBase,
-	functions?: [LootFunction],
+	...LootPoolEntryBase<CT>,
+	functions?: [LootFunctionOf<FT, CT, LRef, ST>],
 }
 
-dispatch minecraft:loot_pool_entry[empty] to SingletonPoolEntry
+dispatch minecraft:loot_pool_entry[empty]<FT, CT, LRef, ST> to SingletonPoolEntry<FT, CT, LRef, ST>
 
 /// Gets block specific drops.
-dispatch minecraft:loot_pool_entry[dynamic] to struct DynamicPoolEntry {
+dispatch minecraft:loot_pool_entry[dynamic]<FT, CT, LRef, ST> to struct DynamicPoolEntry {
 	name: #[id] DynamicDrops,
-	...SingletonPoolEntry,
+	...SingletonPoolEntry<FT, CT, LRef, ST>,
 }
 
 enum(string) DynamicDrops {
@@ -123,59 +138,66 @@ enum(string) DynamicDrops {
 }
 
 /// Adds a single item.
-dispatch minecraft:loot_pool_entry[item] to struct ItemPoolEntry {
+dispatch minecraft:loot_pool_entry[item]<FT, CT, LRef, ST> to struct ItemPoolEntry {
 	name: (
 		#[until="1.21.2"] #[id="item"] string |
 		#[since="1.21.2"] #[id(registry="item", exclude=["air"])] string |	
 	),
-	...SingletonPoolEntry,
+	...SingletonPoolEntry<FT, CT, LRef, ST>,
 }
 
 /// Adds the contents of another loot table.
-dispatch minecraft:loot_pool_entry[loot_table] to struct LootTablePoolEntry {
+dispatch minecraft:loot_pool_entry[loot_table]<FT, CT, LRef, ST> to struct LootTablePoolEntry {
 	#[until="1.20.5"]
 	name: #[id="loot_table"] string,
 	#[since="1.20.5"]
-	value: (
-		#[id="loot_table"] string |
-		LootTable |
-	),
-	...SingletonPoolEntry,
+	value: (LRef | LootTableOf<FT, CT, LRef, ST>),
+	...SingletonPoolEntry<FT, CT, LRef, ST>,
 }
 
 #[since="1.21.11"]
-dispatch minecraft:loot_pool_entry[slots] to struct SlotsPoolEntry {
-	slot_source: SlotSource,
-	...SingletonPoolEntry,
+dispatch minecraft:loot_pool_entry[slots]<FT, CT, LRef, ST> to struct SlotsPoolEntry {
+	slot_source: SlotSourceOf<ST>,
+	...SingletonPoolEntry<FT, CT, LRef, ST>,
 }
 
 /// Adds the contents of an item tag.
-dispatch minecraft:loot_pool_entry[tag] to struct TagPoolEntry {
+dispatch minecraft:loot_pool_entry[tag]<FT, CT, LRef, ST> to struct TagPoolEntry {
 	name: #[id(registry="item",tags="implicit")] string,
 	/// If `true`, drops a random item from the tag. If `false`, drops all items in the tag.
 	expand: boolean,
-	...SingletonPoolEntry,
+	...SingletonPoolEntry<FT, CT, LRef, ST>,
 }
 
-struct CompositePoolEntry {
-	children: [LootPoolEntry],
-	...LootPoolEntryBase,
+type CompositePoolEntry<FT, CT, LRef, ST> = struct {
+	children: [LootPoolEntry<FT, CT, LRef, ST>],
+	...LootPoolEntryBase<CT>,
 }
 
 /// Tests conditions of the child entries and executes the first that can run.
-dispatch minecraft:loot_pool_entry[alternatives] to CompositePoolEntry
+dispatch minecraft:loot_pool_entry[alternatives]<FT, CT, LRef, ST> to CompositePoolEntry<FT, CT, LRef, ST>
 
 /// Executes all child entries when own conditions pass.
-dispatch minecraft:loot_pool_entry[group] to CompositePoolEntry
+dispatch minecraft:loot_pool_entry[group]<FT, CT, LRef, ST> to CompositePoolEntry<FT, CT, LRef, ST>
 
 /// Executes child entries until the first one that can't run due to conditions.
-dispatch minecraft:loot_pool_entry[sequence] to CompositePoolEntry
+dispatch minecraft:loot_pool_entry[sequence]<FT, CT, LRef, ST> to CompositePoolEntry<FT, CT, LRef, ST>
 
-type LootFunction = function::LootFunctionOf<#[id="loot_function_type"] string, #[id="loot_condition_type"] string>
-type NonReferenceLootFunction = function::LootFunctionOf<#[id(registry="loot_function_type",exclude=["reference"])] string, #[id(registry="loot_condition_type",exclude=["reference"])] string>
+type LootFunction = LootFunctionOf<
+	#[id="loot_function_type"] string,
+	#[id="loot_condition_type"] string,
+	#[id="loot_table"] string,
+	#[id="slot_source"] string,
+>
+type NonReferenceLootFunction = LootFunctionOf<
+	#[id(registry="loot_function_type",exclude=["reference"])] string,
+	#[id(registry="loot_condition_type",exclude=["reference"])] string,
+	(),
+	#[id=(registry="slot_source",exclude=["reference"])] string,
+>
 
-type LootCondition = condition::LootConditionOf<#[id="loot_condition_type"] string>
-type NonReferenceLootCondition = condition::LootConditionOf<#[id(registry="loot_condition_type",exclude=["reference"])] string>
+type LootCondition = LootConditionOf<#[id="loot_condition_type"] string>
+type NonReferenceLootCondition = LootConditionOf<#[id(registry="loot_condition_type",exclude=["reference"])] string>
 
 // Until 1.16
 enum(string) LootEntryType {

--- a/java/data/slot_source.mcdoc
+++ b/java/data/slot_source.mcdoc
@@ -8,20 +8,20 @@ dispatch minecraft:resource[slot_source] to SlotSource
 
 type SlotSource = SlotSourceOf<#[id="slot_source_type"] string>
 
-type SlotSourceOf<S> = (TypedSlotSourceOf<S> | [TypedSlotSourceOf<S>])
+type SlotSourceOf<ST> = (TypedSlotSource<ST> | [TypedSlotSource<ST>])
 
-type TypedSlotSourceOf<S> = struct {
-	type: S,
-	...minecraft:slot_source[[type]]<S>,
+type TypedSlotSource<ST> = struct {
+	type: ST,
+	...minecraft:slot_source[[type]]<ST>,
 }
 
-dispatch minecraft:slot_source[empty]<S> to struct {}
+dispatch minecraft:slot_source[empty]<ST> to struct {}
 
-dispatch minecraft:slot_source[group]<S> to struct GroupSlotSource {
-	terms: [SlotSourceOf<S>],
+dispatch minecraft:slot_source[group]<ST> to struct GroupSlotSource {
+	terms: [SlotSourceOf<ST>],
 }
 
-dispatch minecraft:slot_source[slot_range]<S> to struct RangeSlotSource {
+dispatch minecraft:slot_source[slot_range]<ST> to struct RangeSlotSource {
 	#[until="26.3"] ...struct {
 		source: (EntityTarget | BlockEntityTarget),
 	},
@@ -32,24 +32,24 @@ dispatch minecraft:slot_source[slot_range]<S> to struct RangeSlotSource {
 	slots: #[item_slots] string,
 }
 
-dispatch minecraft:slot_source[contents]<S> to struct ContentsSlotSource {
+dispatch minecraft:slot_source[contents]<ST> to struct ContentsSlotSource {
 	/// The slots to search.
-	slot_source: SlotSourceOf<S>,
+	slot_source: SlotSourceOf<ST>,
 	/// If an item targeted by `slot_source` has this container component, selects all items inside.
 	component: #[id] ContainerComponents,
 }
 
-dispatch minecraft:slot_source[filtered]<S> to struct FilterSlotSource {
-	slot_source: SlotSourceOf<S>,
+dispatch minecraft:slot_source[filtered]<ST> to struct FilterSlotSource {
+	slot_source: SlotSourceOf<ST>,
 	item_filter: ItemPredicate,
 }
 
-dispatch minecraft:slot_source[limit_slots]<S> to struct LimitCountSlotSource {
-	slot_source: SlotSourceOf<S>,
+dispatch minecraft:slot_source[limit_slots]<ST> to struct LimitCountSlotSource {
+	slot_source: SlotSourceOf<ST>,
 	limit: int @ 1..,
 }
 
 #[since="26.3"]
-dispatch minecraft:slot_source[reference]<S> to struct SlotSourceReference {
+dispatch minecraft:slot_source[reference]<ST> to struct SlotSourceReference {
 	id: #[id="slot_source"] string,
 }


### PR DESCRIPTION
Reasoning:
Item modifer `set_contents` uses loot tables to generate items. Reference is also disallowed there.

The additional disallowed references are:
- Slot source type `reference` is not allowed
- Loot entry type `loot_table` only accepts inlined loot table.