### PR TITLE
Fix "drop_stragegy" typo

### DIFF
--- a/java/world/component/item.mcdoc
+++ b/java/world/component/item.mcdoc
@@ -167,7 +167,7 @@ struct BlockTransformer {
 	loot?: #[id="loot_table"] string,
 	/// Where the `loot` should drop. \
 	/// Defaults to `from_middle`.
-	drop_stragegy?: BlockTransformDropStrategy,
+	drop_strategy?: BlockTransformDropStrategy,
 	/// How nearby blocks are affected by the transformation. \
 	/// Defaults to `single_block`.
 	transform_type?: BlockTransformType,


### PR DESCRIPTION
Fixed typo in the new `block_transformer` component field `drop_strategy`

`drop_stragegy` -> `drop_strategy`