### PR TITLE
♻️ Rewrite advancement triggers to match in game codecs

### DIFF
--- a/java/data/advancement/trigger.mcdoc
+++ b/java/data/advancement/trigger.mcdoc
@@ -23,13 +23,15 @@ type ParitalRequired<C> = struct {
 	conditions: C,
 }
 
-type AdvancementGeneralPredicate = (
-	#[until="26.3"] [LootCondition] |
-	#[since="26.3"] PredicateRef |
-)
 type AdvancementEntityPredicate = (
 	#[until="26.3"] EntityPredicate |
-	#[since="1.16"] AdvancementGeneralPredicate |
+	#[since="1.16"] #[until="26.3"] [LootCondition] |
+	#[since="26.3"] PredicateRef |
+)
+type AdvancementLocationPredicate = (
+	#[until="1.20"] LocationPredicate |
+	#[since="1.20"] #[until="26.3"] [LootCondition] |
+	#[since="26.3"] PredicateRef |
 )
 
 struct PlayerConditions {
@@ -52,10 +54,7 @@ struct BlockStateConditions {
 type AnyBlockInteractionTrigger = AllOptional<struct {
 	...PlayerConditions,
 	/// Predicate context: Advancement Location.
-	location?: (
-		#[until="1.20"] LocationPredicate |
-		#[since="1.20"] AdvancementGeneralPredicate |
-	),
+	location?: AdvancementLocationPredicate,
 }>
 #[since="1.20.5"]
 dispatch minecraft:trigger[any_block_use] to AnyBlockInteractionTrigger
@@ -139,7 +138,7 @@ dispatch minecraft:trigger[cured_zombie_villager] to CuredZombieVillagerTrigger
 type DefaultBlockInteractionTrigger = AllOptional<struct {
 	...PlayerConditions,
 	/// Predicate context: Block Use.
-	location?: AdvancementGeneralPredicate,
+	location?: AdvancementLocationPredicate,
 }>
 #[since="1.20.5"]
 dispatch minecraft:trigger[default_block_use] to DefaultBlockInteractionTrigger
@@ -277,10 +276,7 @@ struct ItemUesdOnLocationConditions {
 	block?: BlockPredicate,
 	/// Predicate context: Advancement Location.
 	#[since="1.16"]
-	location?: (
-		#[until="1.20"] LocationPredicate |
-		#[since="1.20"] AdvancementGeneralPredicate |
-	),
+	location?: AdvancementLocationPredicate,
 }
 // Until 1.20
 struct PlacedBlockConditions {

--- a/java/data/advancement/trigger.mcdoc
+++ b/java/data/advancement/trigger.mcdoc
@@ -106,7 +106,8 @@ dispatch minecraft:trigger[changed_dimension] to ChangeDimensionTrigger
 
 type ChanneledLightningTrigger = AllOptional<struct {
 	...PlayerConditions,
-	/// Predicate context: Advancement Entity.
+	/// Predicate context: Advancement Entity. \
+	/// Evaluates to true if every victim passes some predicates in the list.
 	victims?: [AdvancementEntityPredicate],
 }>
 /// Player successfully used the Channeling enchantment on an entity.
@@ -310,7 +311,8 @@ type KilledByArrowTrigger = AllOptional<struct {
 	/// The weapon item that was used to fire the arrow.
 	#[since="1.21.2"]
 	fired_from_weapon?: ItemPredicate,
-	/// Predicate context: Advancement Entity.
+	/// Predicate context: Advancement Entity. \
+	/// Evaluates to true if every victim passes some predicates in the list.
 	victims?: [AdvancementEntityPredicate],
 }>
 /// Player killed a mob or player using a projectile shot from a crossbow.

--- a/java/data/advancement/trigger.mcdoc
+++ b/java/data/advancement/trigger.mcdoc
@@ -1,4 +1,5 @@
 use super::super::util::MinMaxBounds
+use super::predicate::BlockPredicate
 use super::predicate::ItemPredicate
 use super::predicate::EntityPredicate
 use super::predicate::LocationPredicate
@@ -13,79 +14,59 @@ use ::java::data::recipe::RecipeListRef
 use ::java::world::component::predicate::PotionsPredicate
 use ::java::util::registry_ref::BlockListRef
 
-type Conditions<C> = struct {
+// Used if C accepts empty object
+type AllOptional<C> = struct {
 	conditions?: C,
 }
-
-type RequiredConditions<C> = struct {
+// Used if C contains required fields
+type ParitalRequired<C> = struct {
 	conditions: C,
 }
 
-type AdvancementPredicateRef = (
+type AdvancementGeneralPredicate = (
 	#[until="26.3"] [LootCondition] |
 	#[since="26.3"] PredicateRef |
 )
-
-type CompositeEntity = (
+type AdvancementEntityPredicate = (
 	#[until="26.3"] EntityPredicate |
-	#[since="1.16"] AdvancementPredicateRef |
+	#[since="1.16"] AdvancementGeneralPredicate |
 )
 
-struct TriggerBase {
+struct PlayerConditions {
+	/// Predicate context: Advancement Entity.
 	#[since="1.16"]
-	player?: CompositeEntity,
+	player?: AdvancementEntityPredicate,
 }
-
-type PlayerTrigger = (
-	#[deprecated="1.16"] #[until="1.19"] LocationPredicate |
-	#[since="1.16"] struct {
-		...TriggerBase,
-		#[until="1.19"]
-		location?: LocationPredicate,
-	} |
-)
-
-struct PlayerInteract {
-	...TriggerBase,
-	item?: ItemPredicate,
-	entity?: CompositeEntity,
-}
-
-struct RecipeCrafted {
-	...TriggerBase,
-	#[until="26.3"]
-	recipe_id: #[id="recipe"] string,
-	#[since="26.3"]
-	recipes: RecipeListRef,
-	ingredients?: [ItemPredicate] @ 1..9,
-}
-
-#[since="1.19"]
-dispatch minecraft:trigger[allay_drop_item_on_block] to Conditions<struct AllayDropItemOnBlock {
-	...TriggerBase,
-	#[until="1.20"]
-	item?: ItemPredicate,
-	location?: (
-		#[until="1.20"] LocationPredicate |
-		#[since="1.20"] AdvancementPredicateRef |
-	),
-}>
-
-#[since="1.20.5"]
-dispatch minecraft:trigger[any_block_use] to Conditions<struct AnyBlockUse {
-	...TriggerBase,
-	location?: AdvancementPredicateRef,
-}>
-
-#[since="1.19"]
-dispatch minecraft:trigger[avoid_vibration] to Conditions<PlayerTrigger>
-
-dispatch minecraft:trigger[bee_nest_destroyed] to Conditions<struct BeeNestDestroyed {
-	...TriggerBase,
+struct BlockStateConditions {
 	#[until="26.3"]
 	block?: #[id="block"] string,
 	#[since="26.3"]
 	blocks?: BlockListRef,
+	state?: (
+		#[until="26.3"] mcdoc:block_states[[block]] |
+		#[since="26.3"] mcdoc:block_states[[blocks]] |
+	),
+}
+
+
+type AnyBlockInteractionTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Location.
+	location?: (
+		#[until="1.20"] LocationPredicate |
+		#[since="1.20"] AdvancementGeneralPredicate |
+	),
+}>
+#[since="1.20.5"]
+dispatch minecraft:trigger[any_block_use] to AnyBlockInteractionTrigger
+
+type BeeNestDestroyedTrigger = AllOptional<struct {
+	...PlayerConditions,
+	#[until="26.3"]
+	block?: #[id="block"] string,
+	#[since="26.3"]
+	blocks?: BlockListRef,
+	// Does not exist in old versions.
 	#[since="26.3"]
 	state?: mcdoc:block_states[[blocks]],
 	/// Number of bees that were inside the bee nest/beehive before it was broken.
@@ -93,221 +74,88 @@ dispatch minecraft:trigger[bee_nest_destroyed] to Conditions<struct BeeNestDestr
 	/// Item used to break the block.
 	item?: ItemPredicate,
 }>
+dispatch minecraft:trigger[bee_nest_destroyed] to BeeNestDestroyedTrigger
 
-dispatch minecraft:trigger[bred_animals] to Conditions<struct BredAnimals {
-	...TriggerBase,
-	parent?: CompositeEntity,
-	partner?: CompositeEntity,
-	child?: CompositeEntity,
+type BredAnimalsTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	parent?: AdvancementEntityPredicate,
+	/// Predicate context: Advancement Entity.
+	partner?: AdvancementEntityPredicate,
+	/// Predicate context: Advancement Entity. \
+	/// Entity may not exist.
+	child?: AdvancementEntityPredicate,
 }>
+dispatch minecraft:trigger[bred_animals] to BredAnimalsTrigger
 
-/// Player took any item out of a brewing stand.
-dispatch minecraft:trigger[brewed_potion] to Conditions<struct BrewedPotion {
-	...TriggerBase,
+type BrewedPotionTrigger = AllOptional<struct {
+	...PlayerConditions,
 	potion?: (
 		#[until="26.3"] #[id="potion"] string |
 		#[since="26.3"] PotionsPredicate |
 	),
 }>
+/// Player took any item out of a brewing stand.
+dispatch minecraft:trigger[brewed_potion] to BrewedPotionTrigger
 
-dispatch minecraft:trigger[changed_dimension] to Conditions<struct ChangedDimension {
-	...TriggerBase,
+type ChangeDimensionTrigger = AllOptional<struct {
+	...PlayerConditions,
 	from?: #[id="dimension"] string,
 	to?: #[id="dimension"] string,
 }>
+dispatch minecraft:trigger[changed_dimension] to ChangeDimensionTrigger
 
-/// Player successfully used the Channeling enchantment on an entity.
-dispatch minecraft:trigger[channeled_lightning] to Conditions<struct ChanneledLightning {
-	...TriggerBase,
-	victims?: [CompositeEntity],
+type ChanneledLightningTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	victims?: [AdvancementEntityPredicate],
 }>
+/// Player successfully used the Channeling enchantment on an entity.
+dispatch minecraft:trigger[channeled_lightning] to ChanneledLightningTrigger
 
-/// Player changed the base of a beacon to a valid base; when the beacon updates itself, occurs both on setup & expansion.
-dispatch minecraft:trigger[construct_beacon] to Conditions<struct ConstructBeacon {
-	...TriggerBase,
+type ConstructBeaconTrigger = AllOptional<struct {
+	...PlayerConditions,
 	/// Tier of the updated beacon base.
 	level?: MinMaxBounds<int>,
 }>
+/// Player changed the base of a beacon to a valid base; when the beacon updates itself, occurs both on setup & expansion.
+dispatch minecraft:trigger[construct_beacon] to ConstructBeaconTrigger
 
-/// Player had a status effect applied or taken from them.
-dispatch minecraft:trigger[consume_item] to Conditions<struct ConsumeItem {
-	...TriggerBase,
+type ConsumeItemTrigger = AllOptional<struct {
+	...PlayerConditions,
 	item?: ItemPredicate,
 }>
+dispatch minecraft:trigger[consume_item] to ConsumeItemTrigger
 
+type CuredZombieVillagerTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	zombie?: AdvancementEntityPredicate,
+	/// Predicate context: Advancement Entity.
+	villager?: AdvancementEntityPredicate,
+}>
+dispatch minecraft:trigger[cured_zombie_villager] to CuredZombieVillagerTrigger
+
+type DefaultBlockInteractionTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Block Use.
+	location?: AdvancementGeneralPredicate,
+}>
 #[since="1.20.5"]
-dispatch minecraft:trigger[crafter_recipe_crafted] to RequiredConditions<RecipeCrafted>
+dispatch minecraft:trigger[default_block_use] to DefaultBlockInteractionTrigger
 
-dispatch minecraft:trigger[cured_zombie_villager] to Conditions<struct CuredZombieVillager {
-	...TriggerBase,
-	villager?: CompositeEntity,
-	zombie?: CompositeEntity,
-}>
-
-#[since="1.20.5"]
-dispatch minecraft:trigger[default_block_use] to Conditions<struct DefaultBlockUse {
-	...TriggerBase,
-	/// The location of the block.
-	location?: AdvancementPredicateRef,
-}>
-
-/// Player had a status effect applied or taken from them.
-dispatch minecraft:trigger[effects_changed] to Conditions<struct EffectsChanged {
-	...TriggerBase,
-	effects?: EntityEffectsPredicate,
-	#[since="1.17"]
-	source?: CompositeEntity,
-}>
-
-/// Player enchanted an item using an enchanting table; not with an anvil or through commands.
-dispatch minecraft:trigger[enchanted_item] to Conditions<struct EnchantedItem {
-	...TriggerBase,
-	item?: ItemPredicate,
-	levels?: MinMaxBounds<int>,
-}>
-
-/// Player stands in a block.
-///
-/// Checked every tick and will trigger for each successful match (up to 8 times, the maximum amount of blocks a player can stand in).
-dispatch minecraft:trigger[enter_block] to Conditions<struct EnterBlock {
-	...TriggerBase,
-	#[until="26.3"]
-	block?: #[id="block"] string,
-	#[since="26.3"]
-	blocks?: BlockListRef,
-	state?: mcdoc:block_states[[block]],
-}>
-
-dispatch minecraft:trigger[entity_hurt_player] to Conditions<struct EntityHurtPlayer {
-	...TriggerBase,
-	damage?: DamagePredicate,
-}>
-
-dispatch minecraft:trigger[entity_killed_player] to Conditions<struct EntityKilledPlayer {
-	...TriggerBase,
-	entity?: CompositeEntity,
-	killing_blow?: DamageSourcePredicate,
-}>
-
-#[since="1.20.5"]
-dispatch minecraft:trigger[fall_after_explosion] to Conditions<struct FallAfterExplosion {
-	...TriggerBase,
+// Since 1.18
+type DistanceTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Where the player started to travel.
 	start_position?: LocationPredicate,
-	distance?: DistancePredicate,
-	cause?: CompositeEntity,
-}>
-
-#[since="1.18"]
-dispatch minecraft:trigger[fall_from_height] to Conditions<struct FallFromHeight {
-	...TriggerBase,
-	start_position?: LocationPredicate,
+	/// How far the player travels.
 	distance?: DistancePredicate,
 }>
-
-dispatch minecraft:trigger[filled_bucket] to Conditions<struct FilledBucket {
-	...TriggerBase,
-	item?: ItemPredicate,
-}>
-
-/// Player successfully caught an item with a fishing rod or pulled an entity.
-dispatch minecraft:trigger[fishing_rod_hooked] to Conditions<struct FishingRodHooked {
-	...TriggerBase,
-	/// Entity that was pulled.
-	entity?: CompositeEntity,
-	/// Item that was caught.
-	item?: ItemPredicate,
-	/// Fishing rod used.
-	rod?: ItemPredicate,
-}>
-
-/// Player killed the last mob of the last wave in a raid.
-dispatch minecraft:trigger[hero_of_the_village] to Conditions<PlayerTrigger>
-
-dispatch minecraft:trigger[impossible] to Conditions<TriggerBase>
-
-dispatch minecraft:trigger[inventory_changed] to Conditions<struct InventoryChanged {
-	...TriggerBase,
-	slots?: struct InventoryChangedSlots {
-		/// Amount of empty slots.
-		empty?: MinMaxBounds<int>,
-		/// Amount of occupied slots.
-		occupied?: MinMaxBounds<int>,
-		/// Amount of slots that are a full stack.
-		full?: MinMaxBounds<int>,
-	},
-	items?: [ItemPredicate],
-}>
-
-/// Any equipped item was damaged or repaired.
-dispatch minecraft:trigger[item_durability_changed] to Conditions<struct ItemDurabilityChanged {
-	...TriggerBase,
-	/// Change in durability (negative numbers are used to indicate a decrease in durability).
-	delta?: MinMaxBounds<int>,
-	/// The resulting durability.
-	durability?: MinMaxBounds<int>,
-	/// The item before its durability changed.
-	item?: ItemPredicate,
-}>
-
-// TODO: List said interactions.
-/// Player interacted with a block with an empty hand or an item. Only occurs for specific registered interactions.
-#[since="1.16"]
-dispatch minecraft:trigger[item_used_on_block] to Conditions<struct ItemUsedOnBlock {
-	...TriggerBase,
-	#[until="1.20"]
-	item?: ItemPredicate,
-	location?: (
-		#[until="1.20"] LocationPredicate |
-		#[since="1.20"] AdvancementPredicateRef |
-	),
-}>
-
-#[since="1.19"]
-dispatch minecraft:trigger[kill_mob_near_sculk_catalyst] to Conditions<struct KillMobNearSculkCatalyst {
-	...TriggerBase,
-	entity?: EntityPredicate,
-	killing_blow?: DamageSourcePredicate,
-}>
-
-/// Player killed a mob or player using a projectile shot from a crossbow.
-#[until="1.21.2"]
-dispatch minecraft:trigger[killed_by_crossbow] to Conditions<struct KilledByCrossbow {
-	...TriggerBase,
-	/// How many different types of entities were killed.
-	unique_entity_types?: MinMaxBounds<int>,
-	victims?: [CompositeEntity],
-}>
-
-#[since="1.21.2"]
-dispatch minecraft:trigger[killed_by_arrow] to Conditions<struct KilledByArrow {
-	...TriggerBase,
-	/// How many different types of entities were killed.
-	unique_entity_types?: MinMaxBounds<int>,
-	/// The weapon item that was used to fire the arrow.
-	fired_from_weapon?: ItemPredicate,
-	victims?: [CompositeEntity],
-}>
-
-/// Player has the levitation status effect.
-dispatch minecraft:trigger[levitation] to Conditions<struct Levitation {
-	...TriggerBase,
-	distance?: DistancePredicate,
-	duration?: MinMaxBounds<int>,
-}>
-
-/// Lightning bolt finished striking (it is already despawned), activates for all players within a 256 block radius of the strike.
-dispatch minecraft:trigger[lightning_strike] to Conditions<struct LightningStrike {
-	...TriggerBase,
-	lightning?: CompositeEntity,
-	bystander?: CompositeEntity,
-}>
-
-/// Activates every 20 ticks (1 second).
-dispatch minecraft:trigger[location] to Conditions<PlayerTrigger>
-
-/// Player returned to the Overworld after traveling to the Nether.
-dispatch minecraft:trigger[nether_travel] to Conditions<struct NetherTravel {
-	...TriggerBase,
+// Absorbed by DistanceTrigger since 1.18
+// Keep maintaining this type to provide more detailed doc comments
+type NetherTravelTrigger = AllOptional<struct {
+	...PlayerConditions,
 	/// Where in the Overworld the player was when they travelled to the Nether.
 	#[since="1.18"]
 	start_position?: LocationPredicate,
@@ -320,107 +168,312 @@ dispatch minecraft:trigger[nether_travel] to Conditions<struct NetherTravel {
 	#[until="1.18"]
 	exited?: LocationPredicate,
 }>
+#[since="1.18"]
+dispatch minecraft:trigger[fall_from_height] to DistanceTrigger
+/// Player returned to the Overworld after traveling to the Nether.
+dispatch minecraft:trigger[nether_travel] to NetherTravelTrigger
+#[since="1.18"]
+dispatch minecraft:trigger[ride_entity_in_lava] to DistanceTrigger
 
-dispatch minecraft:trigger[placed_block] to Conditions<struct PlacedBlock {
-	...TriggerBase,
-	#[until="1.20"]
-	block?: #[id="block"] string,
-	#[until="1.20"]
-	state?: mcdoc:block_states[[block]],
-	/// Item that was used to place the block before the item was consumed.
+type EffectsChangedTrigger = AllOptional<struct {
+	...PlayerConditions,
+	effects?: EntityEffectsPredicate,
+	/// Predicate context: Advancement Entity. \
+	/// Entity may not exist.
+	#[since="1.17"]
+	source?: AdvancementEntityPredicate
+}>
+/// Player had a status effect applied or taken from them.
+dispatch minecraft:trigger[effects_changed] to EffectsChangedTrigger
+
+type EnchantedItemTrigger = AllOptional<struct {
+	...PlayerConditions,
+	item?: ItemPredicate,
+	levels?: MinMaxBounds<int>,
+}>
+/// Player enchanted an item using an enchanting table; not with an anvil or through commands.
+dispatch minecraft:trigger[enchanted_item] to EnchantedItemTrigger
+
+type EnterBlockTrigger = AllOptional<struct {
+	...PlayerConditions,
+	...BlockStateConditions,
+}>
+/// Player stands in a block.
+///
+/// Checked every tick and will trigger for each successful match (up to 8 times, the maximum amount of blocks a player can stand in).
+dispatch minecraft:trigger[enter_block] to EnterBlockTrigger
+
+type EntityHurtPlayerTrigger = AllOptional<struct {
+	...PlayerConditions,
+	damage?: DamagePredicate,
+}>
+dispatch minecraft:trigger[entity_hurt_player] to EntityHurtPlayerTrigger
+
+type FallAfterExplosionTrigger = AllOptional<struct {
+	...PlayerConditions,
+	start_position?: LocationPredicate,
+	distance?: DistancePredicate,
+	/// Predicate context: Advancement Entity. \
+	/// Entity may not exist.
+	cause?: AdvancementEntityPredicate,
+}>
+#[since="1.20.5"]
+dispatch minecraft:trigger[fall_after_explosion] to FallAfterExplosionTrigger
+
+type FilledBucketTrigger = AllOptional<struct {
+	...PlayerConditions,
+	item?: ItemPredicate,
+}>
+dispatch minecraft:trigger[filled_bucket] to FilledBucketTrigger
+
+type FishingRodHookedTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity. \
+	/// Entity that was pulled.
+	/// Or the hook itself if no entity was hooked.
+	entity?: AdvancementEntityPredicate,
+	/// Item that was caught.
+	item?: ItemPredicate,
+	/// Fishing rod used.
+	rod?: ItemPredicate,
+}>
+/// Player successfully caught an item with a fishing rod or pulled an entity.
+dispatch minecraft:trigger[fishing_rod_hooked] to FishingRodHookedTrigger
+
+type ImpossibleTrigger = AllOptional<struct {}>
+dispatch minecraft:trigger[impossible] to ImpossibleTrigger
+
+type InventoryChangeTrigger = AllOptional<struct {
+	...PlayerConditions,
+	slots?: struct InventoryChangedSlots {
+		/// Amount of empty slots.
+		empty?: MinMaxBounds<int>,
+		/// Amount of occupied slots.
+		occupied?: MinMaxBounds<int>,
+		/// Amount of slots that are a full stack.
+		full?: MinMaxBounds<int>,
+	},
+	items?: [ItemPredicate],
+}>
+dispatch minecraft:trigger[inventory_changed] to InventoryChangeTrigger
+
+type ItemDurabilityTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Change in durability (negative numbers are used to indicate a decrease in durability).
+	delta?: MinMaxBounds<int>,
+	/// The resulting durability.
+	durability?: MinMaxBounds<int>,
+	/// The item before its durability changed.
+	item?: ItemPredicate,
+}>
+/// Any equipped item was damaged or repaired.
+dispatch minecraft:trigger[item_durability_changed] to ItemDurabilityTrigger
+
+struct ItemUesdOnLocationConditions {
+	...PlayerConditions,
 	#[until="1.20"]
 	item?: ItemPredicate,
-	/// Where the block was placed.
+	#[until="1.16"]
+	block?: BlockPredicate,
+	/// Predicate context: Advancement Location.
+	#[since="1.16"]
 	location?: (
 		#[until="1.20"] LocationPredicate |
-		#[since="1.20"] AdvancementPredicateRef |
+		#[since="1.20"] AdvancementGeneralPredicate |
 	),
-}>
-
-/// Player generated the contents of a container upon opening it with the set loot table.
+}
+// Until 1.20
+struct PlacedBlockConditions {
+	...PlayerConditions,
+	...BlockStateConditions,
+	/// Item that was used to place the block before the item was consumed.
+	item?: ItemPredicate,
+	/// Predicate context: Advancement Location.
+	location?: LocationPredicate,
+}
+type ItemUsedOnLocationTrigger = AllOptional<ItemUesdOnLocationConditions>
+// Absorbed by ItemUsedOnLocationTrigger since 1.20
+type PlacedBlockTrigger = AllOptional<(
+	#[until="1.20"] PlacedBlockConditions |
+	#[since="1.20"] ItemUesdOnLocationConditions |
+)>
+#[since="1.19"]
+dispatch minecraft:trigger[allay_drop_item_on_block] to ItemUsedOnLocationTrigger
+// TODO: List said interactions.
+/// Player interacted with a block with an empty hand or an item. Only occurs for specific registered interactions.
 #[since="1.16"]
-dispatch minecraft:trigger[player_generates_container_loot] to RequiredConditions<struct PlayerGeneratesContainerLoot {
-	...TriggerBase,
+dispatch minecraft:trigger[item_used_on_block] to ItemUsedOnLocationTrigger
+dispatch minecraft:trigger[placed_block] to PlacedBlockTrigger
+#[until="1.16"]
+dispatch minecraft:trigger[safely_harvest_honey] to ItemUsedOnLocationTrigger
+
+type KilledByArrowTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// How many different types of entities were killed.
+	unique_entity_types?: MinMaxBounds<int>,
+	/// The weapon item that was used to fire the arrow.
+	#[since="1.21.2"]
+	fired_from_weapon?: ItemPredicate,
+	/// Predicate context: Advancement Entity.
+	victims?: [AdvancementEntityPredicate],
+}>
+/// Player killed a mob or player using a projectile shot from a crossbow.
+#[since="1.21.2"]
+dispatch minecraft:trigger[killed_by_arrow] to KilledByArrowTrigger
+/// Player killed a mob or player using a projectile shot from a crossbow.
+#[until="1.21.2"]
+dispatch minecraft:trigger[killed_by_crossbow] to KilledByArrowTrigger
+
+type KilledTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	entity?: AdvancementEntityPredicate,
+	killing_blow?: DamageSourcePredicate,
+}>
+dispatch minecraft:trigger[entity_killed_player, player_killed_entity] to KilledTrigger
+#[since="1.19"]
+dispatch minecraft:trigger[kill_mob_near_sculk_catalyst] to KilledTrigger
+
+type LevitationTrigger = AllOptional<struct {
+	...PlayerConditions,
+	distance?: DistancePredicate,
+	duration?: MinMaxBounds<int>,
+}>
+/// Player has the levitation status effect.
+dispatch minecraft:trigger[levitation] to LevitationTrigger
+
+type LightningStrikeTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	lightning?: AdvancementEntityPredicate,
+	/// Predicate context: Advancement Entity. \
+	/// Evaluates to false if no entities are nearby.
+	bystander?: AdvancementEntityPredicate,
+}>
+/// Lightning bolt finished striking (it is already despawned), activates for all players within a 256 block radius of the strike.
+dispatch minecraft:trigger[lightning_strike] to LightningStrikeTrigger
+
+type LootTableTrigger = ParitalRequired<struct {
+	...PlayerConditions,
 	#[until="26.3"]
 	loot_table: #[id="loot_table"] string,
 	#[since="26.3"]
 	loot_tables: LootTableListRef,
 }>
+/// Player generated the contents of a container upon opening it with the set loot table.
+#[since="1.16"]
+dispatch minecraft:trigger[player_generates_container_loot] to LootTableTrigger
 
-dispatch minecraft:trigger[player_hurt_entity] to Conditions<struct PlayerHurtEntity {
-	...TriggerBase,
-	damage?: DamagePredicate,
-	entity?: CompositeEntity,
+type PickedUpItemTrigger = AllOptional<struct {
+	...PlayerConditions,
+	item?: ItemPredicate,
+	/// Predicate context: Advancement Entity. \
+	/// Entity may not exist.
+	entity?: AdvancementEntityPredicate,
 }>
+/// Player had thrown an item and an entity picked it up.
+#[since="1.16"]
+dispatch minecraft:trigger[thrown_item_picked_up_by_entity] to PickedUpItemTrigger
+/// Player had thrown an item and any player picked it up (optimized shortcut for entity type condition).
+#[since="1.19"]
+dispatch minecraft:trigger[thrown_item_picked_up_by_player] to PickedUpItemTrigger
 
+type PlayerHurtEntityTrigger = AllOptional<struct {
+	...PlayerConditions,
+	damage?: DamagePredicate,
+	/// Predicate context: Advancement Entity.
+	entity?: AdvancementEntityPredicate,
+}>
+dispatch minecraft:trigger[player_hurt_entity] to PlayerHurtEntityTrigger
+
+type PlayerInteractTrigger = AllOptional<struct {
+	...PlayerConditions,
+	item?: ItemPredicate,
+	/// Predicate context: Advancement Entity.
+	entity?: AdvancementEntityPredicate,
+}>
 // TODO: List said interactions.
 /// Only occurs for specific registered interactions.
 #[since="1.16"]
-dispatch minecraft:trigger[player_interacted_with_entity] to Conditions<PlayerInteract>
-
-dispatch minecraft:trigger[player_killed_entity] to Conditions<struct PlayerKilledEntity {
-	...TriggerBase,
-	entity?: CompositeEntity,
-	killing_blow?: DamageSourcePredicate,
-}>
-
+dispatch minecraft:trigger[player_interacted_with_entity] to PlayerInteractTrigger
 #[since="1.21.6"]
-dispatch minecraft:trigger[player_sheared_equipment] to Conditions<PlayerInteract>
+dispatch minecraft:trigger[player_sheared_equipment] to PlayerInteractTrigger
 
+type PlayerTrigger = AllOptional<PlayerConditions>
+// Absorbed by PlayerTrigger since 1.19
+type LocationTrigger = AllOptional<(
+	#[deprecated="1.16"] #[until="1.19"] LocationPredicate |
+	#[since="1.16"] #[until="1.19"] struct {
+		...PlayerConditions,
+		location?: LocationPredicate,
+	} |
+	PlayerConditions |
+)>
+#[since="1.19"]
+dispatch minecraft:trigger[avoid_vibration] to LocationTrigger
+/// Player killed the last mob of the last wave in a raid.
+dispatch minecraft:trigger[hero_of_the_village] to LocationTrigger
+/// Activates every 20 ticks (1 second).
+dispatch minecraft:trigger[location] to LocationTrigger
+dispatch minecraft:trigger[slept_in_bed] to LocationTrigger
+/// Activates every tick (20 times a second). Should only be used in-place of `#minecraft:tick` when utilizing multiple criteria to optimize.
+dispatch minecraft:trigger[tick] to PlayerTrigger
+/// Player caused a raid to start.
+dispatch minecraft:trigger[voluntary_exile] to LocationTrigger
+
+type RecipeCraftedTrigger = ParitalRequired<struct {
+	...PlayerConditions,
+	#[until="26.3"]
+	recipe_id: #[id="recipe"] string,
+	#[since="26.3"]
+	recipes: RecipeListRef,
+	ingredients?: [ItemPredicate] @ 1..9,
+}>
+#[since="1.20.5"]
+dispatch minecraft:trigger[crafter_recipe_crafted] to RecipeCraftedTrigger
 #[since="1.20"]
-dispatch minecraft:trigger[recipe_crafted] to RequiredConditions<RecipeCrafted>
+dispatch minecraft:trigger[recipe_crafted] to RecipeCraftedTrigger
 
-/// Player unlocked a recipe by either crafting it, receiving it in an advancement reward, using a knowledge book, or receiving it through `/recipe`.
-dispatch minecraft:trigger[recipe_unlocked] to RequiredConditions<struct RecipeUnlocked {
-	...TriggerBase,
+type RecipeUnlockedTrigger = ParitalRequired<struct {
+	...PlayerConditions,
 	#[until="26.3"]
 	recipe: #[id="recipe"] string,
 	#[since="26.3"]
 	recipes: RecipeListRef,
 }>
+/// Player unlocked a recipe by either crafting it, receiving it in an advancement reward, using a knowledge book, or receiving it through `/recipe`.
+dispatch minecraft:trigger[recipe_unlocked] to RecipeUnlockedTrigger
 
-#[since="1.18"]
-dispatch minecraft:trigger[ride_entity_in_lava] to Conditions<struct RideEntityInLava {
-	...TriggerBase,
-	start_position?: LocationPredicate,
-	distance?: DistancePredicate,
+type SlideDownBlockTrigger = AllOptional<struct {
+	...PlayerConditions,
+	...BlockStateConditions,
 }>
+dispatch minecraft:trigger[slide_down_block] to SlideDownBlockTrigger
 
-#[until="1.16"]
-dispatch minecraft:trigger[safely_harvest_honey] to Conditions<struct SafelyHarvestHoney {
-	...TriggerBase,
-	block?: struct HoneyHarvestedBlock {
-		block?: #[id="block"] string,
-		tag?: #[id(registry="block",tags="implicit")] string,
-	},
-	item?: ItemPredicate,
-}>
-
-dispatch minecraft:trigger[shot_crossbow] to Conditions<struct ShotCrossbow {
-	...TriggerBase,
+type ShotCrossbowTrigger = AllOptional<struct {
+	...PlayerConditions,
 	/// Crossbow that was used.
 	item?: ItemPredicate,
 }>
+dispatch minecraft:trigger[shot_crossbow] to ShotCrossbowTrigger
 
-dispatch minecraft:trigger[slept_in_bed] to Conditions<PlayerTrigger>
-
-dispatch minecraft:trigger[slide_down_block] to Conditions<struct SlideDownBlock {
-	...TriggerBase,
-	#[until="26.3"]
-	block?: #[id="block"] string,
-	#[since="26.3"]
-	blocks?: BlockListRef,
-}>
-
-#[since="1.21.11"]
-dispatch minecraft:trigger[spear_mobs] to Conditions<struct SpearMobs {
-	...TriggerBase,
+type SpearMobsTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Minimum mob count required.
 	count?: int @ 1..,
 }>
+#[since="1.21.11"]
+dispatch minecraft:trigger[spear_mobs] to SpearMobsTrigger
 
+type StartRidingTrigger = AllOptional<PlayerConditions>
 #[since="1.17"]
-dispatch minecraft:trigger[started_riding] to Conditions<TriggerBase>
+dispatch minecraft:trigger[started_riding] to StartRidingTrigger
 
+type SummonedEntityTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	entity?: AdvancementEntityPredicate,
+}>
 /// Activated when the last required block is placed for summoning
 /// iron golems (pumpkin and iron blocks), snow golems (pumpkin and snow blocks), the ender dragon (end crystals),
 /// or the wither (wither skulls and soul sand/soul soil).
@@ -431,67 +484,51 @@ dispatch minecraft:trigger[started_riding] to Conditions<TriggerBase>
 /// - Ender dragon: 192 blocks from `0, 128, 0`.
 ///
 /// (Spawn eggs, commands and mob spawners do not activate this)
-dispatch minecraft:trigger[summoned_entity] to Conditions<struct SummonedEntity {
-	...TriggerBase,
-	entity?: CompositeEntity,
-}>
+dispatch minecraft:trigger[summoned_entity] to SummonedEntityTrigger
 
-dispatch minecraft:trigger[tame_animal] to Conditions<struct TameAnimal {
-	...TriggerBase,
-	entity?: CompositeEntity,
+type TameAnimalTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	entity?: AdvancementEntityPredicate,
 }>
+dispatch minecraft:trigger[tame_animal] to TameAnimalTrigger
 
-#[since="1.16"]
-dispatch minecraft:trigger[target_hit] to Conditions<struct TargetHit {
-	...TriggerBase,
-	projectile?: CompositeEntity,
-	shooter?: CompositeEntity,
+type TargetBlockTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	projectile?: AdvancementEntityPredicate,
 	signal_strength?: MinMaxBounds<int>,
 }>
-
-/// Player had thrown an item and an entity picked it up.
 #[since="1.16"]
-dispatch minecraft:trigger[thrown_item_picked_up_by_entity] to Conditions<struct ThrownItemPickedUpByEntity {
-	...TriggerBase,
+dispatch minecraft:trigger[target_hit] to TargetBlockTrigger
+
+type TradeTrigger = AllOptional<struct {
+	...PlayerConditions,
+	/// Predicate context: Advancement Entity.
+	villager?: AdvancementEntityPredicate,
+	/// Item that was purchased. \
+	/// `count` tag checks the item count from one trade, not the total amount traded for.
 	item?: ItemPredicate,
-	entity?: CompositeEntity,
 }>
+dispatch minecraft:trigger[villager_trade] to TradeTrigger
 
-/// Player had thrown an item and any player picked it up (optimized shortcut for entity type condition).
-#[since="1.19"]
-dispatch minecraft:trigger[thrown_item_picked_up_by_player] to Conditions<struct ThrownItemPickedUpByPlayer {
-	...TriggerBase,
-	item?: ItemPredicate,
-	entity?: CompositeEntity,
-}>
-
-/// Activates every tick (20 times a second). Should only be used in-place of `#minecraft:tick` when utilizing multiple criteria to optimize.
-dispatch minecraft:trigger[tick] to Conditions<TriggerBase>
-
-/// Player used an eye of ender (in a world where strongholds generate).
-dispatch minecraft:trigger[used_ender_eye] to Conditions<struct UsedEnderEye {
-	...TriggerBase,
+type UsedEnderEyeTrigger = AllOptional<struct {
+	...PlayerConditions,
 	/// Horizontal distance between the player and the stronghold.
-	distance?: MinMaxBounds<float>,
+	distance?: MinMaxBounds<double>,
 }>
+/// Player used an eye of ender (in a world where strongholds generate).
+dispatch minecraft:trigger[used_ender_eye] to UsedEnderEyeTrigger
 
-dispatch minecraft:trigger[used_totem] to Conditions<struct UsedTotem {
-	...TriggerBase,
+type UsedTotemTrigger = AllOptional<struct {
+	...PlayerConditions,
 	item?: ItemPredicate,
 }>
+dispatch minecraft:trigger[used_totem] to UsedTotemTrigger
 
+type UsingItemTrigger = AllOptional<struct {
+	...PlayerConditions,
+	item?: ItemPredicate,
+}>
 #[since="1.17"]
-dispatch minecraft:trigger[using_item] to Conditions<struct UsingItem {
-	...TriggerBase,
-	item?: ItemPredicate,
-}>
-
-dispatch minecraft:trigger[villager_trade] to Conditions<struct VillagerTrade {
-	...TriggerBase,
-	villager?: CompositeEntity,
-	/// Item that was purchased. `count` tag checks the item count from one trade, not the total amount traded for.
-	item?: ItemPredicate,
-}>
-
-/// Player caused a raid to start.
-dispatch minecraft:trigger[voluntary_exile] to Conditions<PlayerTrigger>
+dispatch minecraft:trigger[using_item] to UsingItemTrigger

--- a/java/data/advancement/trigger.mcdoc
+++ b/java/data/advancement/trigger.mcdoc
@@ -107,7 +107,7 @@ dispatch minecraft:trigger[changed_dimension] to ChangeDimensionTrigger
 type ChanneledLightningTrigger = AllOptional<struct {
 	...PlayerConditions,
 	/// Predicate context: Advancement Entity. \
-	/// Evaluates to true if every victim passes some predicates in the list.
+	/// Evaluates to true if every predicate in the list matches some victims.
 	victims?: [AdvancementEntityPredicate],
 }>
 /// Player successfully used the Channeling enchantment on an entity.
@@ -312,7 +312,7 @@ type KilledByArrowTrigger = AllOptional<struct {
 	#[since="1.21.2"]
 	fired_from_weapon?: ItemPredicate,
 	/// Predicate context: Advancement Entity. \
-	/// Evaluates to true if every victim passes some predicates in the list.
+	/// Evaluates to true if every predicate in the list matches some victims.
 	victims?: [AdvancementEntityPredicate],
 }>
 /// Player killed a mob or player using a projectile shot from a crossbow.


### PR DESCRIPTION
- Made advancement triggers easier to maintain.
- Added doc comments about predicate contexts.
- Fixed following issues:
  - 26.3+ `enter_block` uses correct dynamic key for blockstate property now (missed in #116).
  - `impossible` trigger reads nothing (rather than player condition).
  - `safely_harvest_honey` (until 1.16) uses full block predicate (in addition to `block` and `tag`).
  - `slide_down_block` should be able to check blockstate properties.
  - `target_hit` should not have `shooter` field.