### PR TITLE
✨ Add item count pseudo predicate

### DIFF
--- a/java/world/component/mod.mcdoc
+++ b/java/world/component/mod.mcdoc
@@ -1,4 +1,3 @@
-use ::java::data::util::MinMaxBounds
 use ::java::util::text::Text
 
 // Transient data component IDs are disallowed in:

--- a/java/world/component/mod.mcdoc
+++ b/java/world/component/mod.mcdoc
@@ -1,3 +1,4 @@
+use ::java::data::util::MinMaxBounds
 use ::java::util::text::Text
 
 // Transient data component IDs are disallowed in:
@@ -25,6 +26,9 @@ struct DataComponentPredicate {
 		#[since="1.21.11"] minecraft:data_component_existence_predicate[[%key]] |
 	),
 }
+
+// Used by item predicate command argument
+type ItemCountPseudoPredicate = MinMaxBounds<int @ 1..99>
 
 
 dispatch minecraft:data_component[custom_data] to CustomData

--- a/java/world/component/mod.mcdoc
+++ b/java/world/component/mod.mcdoc
@@ -27,9 +27,6 @@ struct DataComponentPredicate {
 	),
 }
 
-// Used by item predicate command argument
-type ItemCountPseudoPredicate = MinMaxBounds<int @ 1..99>
-
 
 dispatch minecraft:data_component[custom_data] to CustomData
 

--- a/java/world/component/predicate.mcdoc
+++ b/java/world/component/predicate.mcdoc
@@ -8,6 +8,9 @@ use ::java::util::text::Text
 use ::java::world::component::CustomData
 use ::java::world::component::item::FireworkShape
 
+// Used by item predicate command argument
+type ItemCountPseudoPredicate = MinMaxBounds<int @ 1..99>
+
 // This is necessary for super::DataComponentPredicate to work in 1.21.11
 dispatch minecraft:data_component_predicate[%unknown] to ()
 


### PR DESCRIPTION
The new type reference added in SpyglassMC/Spyglass#2066.
Its number check is stricter than the in-game unbounded `int` and the previously hardcoded `int @ 0..`.