### PR TITLE
🐛 `AND` key should be able allowed in block state definition

### DIFF
--- a/java/assets/block_state_definition.mcdoc
+++ b/java/assets/block_state_definition.mcdoc
@@ -39,6 +39,9 @@ type MultiPartCondition = (
 		OR: [MultiPartCondition],
 	} |
 	struct MultiPartAnd {
+		AND: [MultiPartCondition],
+	} |
+	struct MultiPartBlockStates {
 		[string]: string, // TODO: block state key
 	} |
 )


### PR DESCRIPTION
<img width="700" height="270" alt="image" src="https://github.com/user-attachments/assets/b8127775-fd85-44fe-b3b7-553015d024b1" />

Writing this is allowed in block state definition.