### PR TITLE
🐛 Allow extra primitive types in text component `with` list

### DIFF
--- a/java/util/text.mcdoc
+++ b/java/util/text.mcdoc
@@ -10,6 +10,16 @@ type Text = (
 	[Text] @ 1.. |
 )
 
+type ExtraPrimitives = (
+	boolean |
+	#[since="1.21.5"] byte |
+	#[since="1.21.5"] short |
+	int |
+	#[since="1.21.5"] long |
+	float |
+	#[since="1.21.5"] double |
+)
+
 type TextObject = (
 	struct NormalText {
 		text: string,
@@ -21,7 +31,7 @@ type TextObject = (
 		translate: #[translation_key] string,
 		#[since="1.19.4"]
 		fallback?: #[translation_value] string,
-		with?: [Text] @ 1..,
+		with?: [(Text | ExtraPrimitives)] @ 1..,
 		#[since="1.20.3"]
 		type?: "translatable",
 		...TextBase,

--- a/java/util/text.mcdoc
+++ b/java/util/text.mcdoc
@@ -10,16 +10,6 @@ type Text = (
 	[Text] @ 1.. |
 )
 
-type ExtraPrimitives = (
-	boolean |
-	#[since="1.21.5"] byte |
-	#[since="1.21.5"] short |
-	int |
-	#[since="1.21.5"] long |
-	float |
-	#[since="1.21.5"] double |
-)
-
 type TextObject = (
 	struct NormalText {
 		text: string,
@@ -31,7 +21,7 @@ type TextObject = (
 		translate: #[translation_key] string,
 		#[since="1.19.4"]
 		fallback?: #[translation_value] string,
-		with?: [(Text | ExtraPrimitives)] @ 1..,
+		with?: [TranslationArg] @ 1..,
 		#[since="1.20.3"]
 		type?: "translatable",
 		...TextBase,
@@ -106,6 +96,17 @@ type TextObject = (
 		type?: "object",
 		...TextBase,
 	} |
+)
+
+type TranslationArg = (
+	Text |
+	boolean |
+	#[since="1.21.5"] byte |
+	#[since="1.21.5"] short |
+	int |
+	#[since="1.21.5"] long |
+	float |
+	#[since="1.21.5"] double |
 )
 
 struct ObjectTextConfig {


### PR DESCRIPTION
**Implemented Jank**

Allow boolean and numbers in the `with` list of translated component. This matches `TranslatableContents.ARG_CODEC`.
Boolean and numbers are explicitly allowed and are used by vanilla game (e.g. command block `LastOutput`). It will be confusing if SNBT produced by F3+I has errors in Spyglass.

**Unimplemented Janks**

The serializer didn't output these janks. It was allowed because the pre-1.20.3 old deserializer was too lenient.
It isn't a good practice to write this kind of text component so these janks are not implemented in this PR.

1. All JSON primitives were valid text component (e.g. `/tellraw @s 1.23` was valid).
2. Boolean parser accepted `"true"` as `true` (and other strings as `false`).